### PR TITLE
Fake repository

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\skjh0\.android\avd\Pixel_3a_XL_API_30.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2021-12-09T02:53:23.276045100Z" />
+  </component>
+</project>

--- a/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/CommentViewModelTest.kt
+++ b/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/CommentViewModelTest.kt
@@ -3,12 +3,12 @@ package com.ama.algorithmmanagement.viewmodel.test
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.ama.algorithmmanagement.fake.*
+import com.ama.algorithmmanagement.utils.DateUtils
 import com.ama.algorithmmanagement.utils.combineWith
 import com.ama.algorithmmanagement.utils.getOrAwaitValue
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
-
 import org.junit.Test
 
 class CommentViewModelTest {
@@ -21,20 +21,24 @@ class CommentViewModelTest {
 
     @Before
     fun init() {
-        val fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
+        val fakeSharedPreference = FakeSharedPreference()
 
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference.setUserId("skjh0818")
         fakeSharedPreference.setTierType(1)
 
         val fakeFirebaseReference = FakeFirebaseReference(
-            ApplicationProvider.getApplicationContext(),
-            FakeFirebaseDataProvider(), fakeSharedPreference
+            FakeFirebaseDataProvider(), DateUtils.createDate()
         )
 
-        val fakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider(fakeSharedPreference))
+        val fakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider())
 
         testCommentViewModel = TestCommentViewModel(
-            FakeRepository(fakeFirebaseReference, fakeNetworkService)
+            FakeRepository(
+                ApplicationProvider.getApplicationContext(),
+                fakeFirebaseReference,
+                fakeNetworkService,
+                fakeSharedPreference
+            )
         )
     }
 

--- a/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/FakeSharedPreferenceTest.kt
+++ b/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/FakeSharedPreferenceTest.kt
@@ -1,0 +1,40 @@
+package com.ama.algorithmmanagement.viewmodel.test
+
+import com.ama.algorithmmanagement.fake.FakeNetWorkDataProvider
+import com.ama.algorithmmanagement.fake.FakeNetworkService
+import com.ama.algorithmmanagement.fake.FakeSharedPreference
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+
+import org.junit.Test
+
+class FakeSharedPreferenceTest {
+    lateinit var mFakeNetworkService: FakeNetworkService
+    lateinit var mFakeSharedPref: FakeSharedPreference
+
+    @Before
+    fun init() {
+        mFakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider())
+        mFakeSharedPref = FakeSharedPreference()
+    }
+
+    @Test
+    fun setSolvedProblems() = runBlocking {
+        //given
+        val problems = mFakeNetworkService.getSolvedProblems("skjh0818")
+
+        //when
+        //obj - > json
+        mFakeSharedPref.setSolvedProblems(problems)
+
+        //then
+        //json -> obj
+        val data = mFakeSharedPref.getSolvedProblems()
+
+        assertEquals(data?.problemList?.get(0)?.titleKo, "A+B")
+        assertEquals(data?.problemList?.get(0)?.problemId, 1000)
+    }
+
+
+}

--- a/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/FakeSharedPreferenceTest.kt
+++ b/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/FakeSharedPreferenceTest.kt
@@ -4,9 +4,8 @@ import com.ama.algorithmmanagement.fake.FakeNetWorkDataProvider
 import com.ama.algorithmmanagement.fake.FakeNetworkService
 import com.ama.algorithmmanagement.fake.FakeSharedPreference
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
-
 import org.junit.Test
 
 class FakeSharedPreferenceTest {

--- a/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/NetworkServiceTest.kt
+++ b/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/NetworkServiceTest.kt
@@ -1,0 +1,71 @@
+package com.ama.algorithmmanagement.viewmodel.test
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.ama.algorithmmanagement.fake.*
+import com.ama.algorithmmanagement.utils.DateUtils
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class NetworkServiceTest {
+
+    lateinit var fakeRepository: FakeRepository
+    var mUserId: String? = null
+
+    @Before
+    fun init() {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val fakeSharedPreference = FakeSharedPreference()
+        val fakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider())
+
+        fakeSharedPreference.setUserId("skjh0818")
+
+        mUserId = fakeSharedPreference.getUserId()
+
+        val fakeFirebaseReference =
+            FakeFirebaseReference(FakeFirebaseDataProvider(), DateUtils.createDate())
+
+        fakeRepository =
+            FakeRepository(context, fakeFirebaseReference, fakeNetworkService, fakeSharedPreference)
+    }
+
+
+    @Test
+    fun getSearchProblemList() = runBlocking {
+        //then
+        val lst = fakeRepository.getSearchProblemList(1111)
+
+        assertEquals(lst.problemList?.size, 30)
+        assertEquals(lst.problemList?.get(0)?.problemId, 1111)
+        assertEquals(lst.problemList?.get(0)?.level, 1)
+        assertEquals(lst.problemList?.get(0)?.titleKo, "A+B")
+    }
+
+
+    @Test
+    fun getUserStats() = runBlocking {
+        //then
+        val stats = fakeRepository.getUserStats()
+
+        assertEquals(stats[0].level, 0)
+        assertEquals(stats[0].total, 116)
+        assertEquals(stats[0].solved, 5)
+        assertEquals(stats[0].partial, 0)
+        assertEquals(stats[0].tried, 0)
+
+    }
+
+    @Test
+    fun getBOJInfo() = runBlocking {
+        //then
+        val lst = fakeRepository.getBOJUserInfo()
+
+        assertEquals(lst[0].status, "solved")
+        assertEquals(lst[0].id, 1000)
+        assertEquals(lst[14].status, "tried")
+        assertEquals(lst[14].id, 1014)
+
+    }
+}

--- a/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/TestChildCommentViewModelTest.kt
+++ b/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/TestChildCommentViewModelTest.kt
@@ -3,9 +3,10 @@ package com.ama.algorithmmanagement.viewmodel.test
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.ama.algorithmmanagement.fake.*
+import com.ama.algorithmmanagement.utils.DateUtils
 import com.ama.algorithmmanagement.utils.combineWith
 import com.ama.algorithmmanagement.utils.getOrAwaitValue
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -18,20 +19,19 @@ class TestChildCommentViewModelTest {
 
     @Before
     fun init() {
-        val fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
+        val fakeSharedPreference = FakeSharedPreference()
 
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference.setUserId("skjh0818")
         fakeSharedPreference.setTierType(1)
 
         val fakeFirebaseReference = FakeFirebaseReference(
-            ApplicationProvider.getApplicationContext(),
-            FakeFirebaseDataProvider(), fakeSharedPreference
+            FakeFirebaseDataProvider(), DateUtils.createDate()
         )
 
-        val fakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider(fakeSharedPreference))
+        val fakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider())
 
         testChildCommentViewModel = TestChildCommentViewModel(
-            FakeRepository(fakeFirebaseReference, fakeNetworkService)
+            FakeRepository(ApplicationProvider.getApplicationContext(),fakeFirebaseReference, fakeNetworkService,fakeSharedPreference)
         )
     }
 
@@ -78,7 +78,7 @@ class TestChildCommentViewModelTest {
             }
         }
 
-        assertEquals(lst.size, 10)
+        assertEquals(lst.size, 5)
         assertEquals(lst[0].comment, "hello0")
         assertEquals(lst[1].comment, "hello1")
         assertEquals(lst[2].comment, "hello2")

--- a/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/TestIdeaViewModelTest.kt
+++ b/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/TestIdeaViewModelTest.kt
@@ -2,9 +2,9 @@ package com.ama.algorithmmanagement.viewmodel.test
 
 import androidx.test.core.app.ApplicationProvider
 import com.ama.algorithmmanagement.fake.*
-import org.junit.Assert.*
+import com.ama.algorithmmanagement.utils.DateUtils
+import org.junit.Assert.assertEquals
 import org.junit.Before
-
 import org.junit.Test
 
 class TestIdeaViewModelTest {
@@ -13,51 +13,57 @@ class TestIdeaViewModelTest {
 
     @Before
     fun init() {
-        val fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
+        val fakeSharedPreference = FakeSharedPreference()
 
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference.setUserId("skjh0818")
         fakeSharedPreference.setTierType(1)
 
         val fakeFirebaseReference = FakeFirebaseReference(
-            ApplicationProvider.getApplicationContext(),
-            FakeFirebaseDataProvider(), fakeSharedPreference
+            FakeFirebaseDataProvider(), DateUtils.createDate()
         )
 
-        val fakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider(fakeSharedPreference))
+        val fakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider())
 
 
         testIdeaViewModelTest =
-            TestIdeaViewModel(FakeRepository(fakeFirebaseReference, fakeNetworkService))
+            TestIdeaViewModel(
+                FakeRepository(
+                    ApplicationProvider.getApplicationContext(),
+                    fakeFirebaseReference,
+                    fakeNetworkService,
+                    fakeSharedPreference
+                )
+            )
     }
 
 
     @Test
     fun getIdeaInfos() {
         //given
-        testIdeaViewModelTest.setIdeaInfo(null,"dp를 이용하면 좋지 않을까?",1111)
+        testIdeaViewModelTest.setIdeaInfo(null, "dp를 이용하면 좋지 않을까?", 1111)
         testIdeaViewModelTest.getIdeaInfos(1111)
 
         //when
         val infos = testIdeaViewModelTest.ideaLst
 
-        assertEquals(infos[0].comment,"dp를 이용하면 좋지 않을까?")
-        assertEquals(infos[0].url,null)
+        assertEquals(infos[0].comment, "dp를 이용하면 좋지 않을까?")
+        assertEquals(infos[0].url, null)
     }
 
     @Test
     fun getIdeaInfos_moreThanOne() {
         //given
-        testIdeaViewModelTest.setIdeaInfo(null,"dp를 이용하면 좋지 않을까?",1111)
-        testIdeaViewModelTest.setIdeaInfo(null,"투 포인터 이용하자",1111)
-        testIdeaViewModelTest.setIdeaInfo(null,"그래프를 이용하자",1111)
+        testIdeaViewModelTest.setIdeaInfo(null, "dp를 이용하면 좋지 않을까?", 1111)
+        testIdeaViewModelTest.setIdeaInfo(null, "투 포인터 이용하자", 1111)
+        testIdeaViewModelTest.setIdeaInfo(null, "그래프를 이용하자", 1111)
         testIdeaViewModelTest.getIdeaInfos(1111)
 
         //when
         val infos = testIdeaViewModelTest.ideaLst
 
-        assertEquals(infos[0].comment,"dp를 이용하면 좋지 않을까?")
-        assertEquals(infos[1].comment,"투 포인터 이용하자")
-        assertEquals(infos[2].comment,"그래프를 이용하자")
+        assertEquals(infos[0].comment, "dp를 이용하면 좋지 않을까?")
+        assertEquals(infos[1].comment, "투 포인터 이용하자")
+        assertEquals(infos[2].comment, "그래프를 이용하자")
 
     }
 }

--- a/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/TestTipViewModelTest.kt
+++ b/app/src/androidTest/java/com/ama/algorithmmanagement/viewmodel/test/TestTipViewModelTest.kt
@@ -3,12 +3,11 @@ package com.ama.algorithmmanagement.viewmodel.test
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.ama.algorithmmanagement.fake.*
-
+import com.ama.algorithmmanagement.utils.DateUtils
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
-import org.junit.Assert.*
-
 import org.junit.Test
 
 class TestTipViewModelTest {
@@ -20,20 +19,24 @@ class TestTipViewModelTest {
 
     @Before
     fun init() {
-        val fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
+        val fakeSharedPreference = FakeSharedPreference()
 
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference.setUserId("skjh0818")
         fakeSharedPreference.setTierType(1)
 
         val fakeFirebaseReference = FakeFirebaseReference(
-            ApplicationProvider.getApplicationContext(),
-            FakeFirebaseDataProvider(), fakeSharedPreference
+            FakeFirebaseDataProvider(), DateUtils.createDate()
         )
 
-        mFakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider(fakeSharedPreference))
+        mFakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider())
 
         testTipViewModel = TestTipViewModel(
-            FakeRepository(fakeFirebaseReference, mFakeNetworkService)
+            FakeRepository(
+                ApplicationProvider.getApplicationContext(),
+                fakeFirebaseReference,
+                mFakeNetworkService,
+                fakeSharedPreference
+            )
         )
     }
 
@@ -43,16 +46,16 @@ class TestTipViewModelTest {
         val problem = mFakeNetworkService.getProblem(1111)
 
         //when
-        testTipViewModel.setTippingProblem(problem,false,"재귀를 사용하면 좋다")
+        testTipViewModel.setTippingProblem(problem, false, "재귀를 사용하면 좋다")
 
         val lst = testTipViewModel.tipProblems
 
         //then
-        assertEquals(lst[0].tipComment,"재귀를 사용하면 좋다")
-        assertEquals(lst[0].isShow,false)
-        assertEquals(lst[0].problem.problemId,1111)
-        assertEquals(lst[0].problem.titleKo,"A+B")
-        assertEquals(lst[0].problem.level,1)
+        assertEquals(lst[0].tipComment, "재귀를 사용하면 좋다")
+        assertEquals(lst[0].isShow, false)
+        assertEquals(lst[0].problem.problemId, 1111)
+        assertEquals(lst[0].problem.titleKo, "A+B")
+        assertEquals(lst[0].problem.level, 1)
 
     }
 
@@ -64,30 +67,30 @@ class TestTipViewModelTest {
         val problem3 = mFakeNetworkService.getProblem(3333)
 
         //when
-        testTipViewModel.setTippingProblem(problem,false,"재귀를 사용하면 좋다")
-        testTipViewModel.setTippingProblem(problem2,true,"그래프 사용하면 좋다")
-        testTipViewModel.setTippingProblem(problem3,true,"투포인터 사용하면 좋다")
+        testTipViewModel.setTippingProblem(problem, false, "재귀를 사용하면 좋다")
+        testTipViewModel.setTippingProblem(problem2, true, "그래프 사용하면 좋다")
+        testTipViewModel.setTippingProblem(problem3, true, "투포인터 사용하면 좋다")
 
         val lst = testTipViewModel.tipProblems
 
         //then
-        assertEquals(lst[0].tipComment,"재귀를 사용하면 좋다")
-        assertEquals(lst[0].isShow,false)
-        assertEquals(lst[0].problem.problemId,1111)
-        assertEquals(lst[0].problem.titleKo,"A+B")
-        assertEquals(lst[0].problem.level,1)
+        assertEquals(lst[0].tipComment, "재귀를 사용하면 좋다")
+        assertEquals(lst[0].isShow, false)
+        assertEquals(lst[0].problem.problemId, 1111)
+        assertEquals(lst[0].problem.titleKo, "A+B")
+        assertEquals(lst[0].problem.level, 1)
 
-        assertEquals(lst[1].tipComment,"그래프 사용하면 좋다")
-        assertEquals(lst[1].isShow,true)
-        assertEquals(lst[1].problem.problemId,2222)
-        assertEquals(lst[1].problem.titleKo,"A+B")
-        assertEquals(lst[1].problem.level,1)
+        assertEquals(lst[1].tipComment, "그래프 사용하면 좋다")
+        assertEquals(lst[1].isShow, true)
+        assertEquals(lst[1].problem.problemId, 2222)
+        assertEquals(lst[1].problem.titleKo, "A+B")
+        assertEquals(lst[1].problem.level, 1)
 
-        assertEquals(lst[2].tipComment,"투포인터 사용하면 좋다")
-        assertEquals(lst[2].isShow,true)
-        assertEquals(lst[2].problem.problemId,3333)
-        assertEquals(lst[2].problem.titleKo,"A+B")
-        assertEquals(lst[2].problem.level,1)
+        assertEquals(lst[2].tipComment, "투포인터 사용하면 좋다")
+        assertEquals(lst[2].isShow, true)
+        assertEquals(lst[2].problem.problemId, 3333)
+        assertEquals(lst[2].problem.titleKo, "A+B")
+        assertEquals(lst[2].problem.level, 1)
 
     }
 

--- a/app/src/main/java/com/ama/algorithmmanagement/Activity/kDefault/KCallAPIActivity.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Activity/kDefault/KCallAPIActivity.kt
@@ -4,15 +4,9 @@ import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import com.ama.algorithmmanagement.Adapter.KDefaultRecyclerViewAdapter
 import com.ama.algorithmmanagement.Base.KBaseActivity
-import com.ama.algorithmmanagement.Model.Problems
-import com.ama.algorithmmanagement.Network.KAPIGenerator
 import com.ama.algorithmmanagement.R
 import com.ama.algorithmmanagement.databinding.DefaultActivityCallApiBinding
 import com.ama.algorithmmanagement.viewmodel.kDefault.KAPICallViewModel
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
-import timber.log.Timber
 
 class KCallAPIActivity :
     KBaseActivity<DefaultActivityCallApiBinding>(R.layout.default_activity_call_api) {

--- a/app/src/main/java/com/ama/algorithmmanagement/Activity/kDefault/KCallAPIActivity.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Activity/kDefault/KCallAPIActivity.kt
@@ -3,9 +3,12 @@ package com.ama.algorithmmanagement.Activity.kDefault
 import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import com.ama.algorithmmanagement.Adapter.KDefaultRecyclerViewAdapter
+import com.ama.algorithmmanagement.Application.AMAApplication
 import com.ama.algorithmmanagement.Base.KBaseActivity
 import com.ama.algorithmmanagement.R
+import com.ama.algorithmmanagement.Repositories.RepositoryLocator
 import com.ama.algorithmmanagement.databinding.DefaultActivityCallApiBinding
+import com.ama.algorithmmanagement.utils.BaseViewModelFactory
 import com.ama.algorithmmanagement.viewmodel.kDefault.KAPICallViewModel
 
 class KCallAPIActivity :
@@ -15,7 +18,11 @@ class KCallAPIActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        callViewModel = ViewModelProvider(this)[KAPICallViewModel::class.java]
+        callViewModel = ViewModelProvider(
+            this,
+            BaseViewModelFactory(RepositoryLocator().getFakeRepository(AMAApplication.INSTANCE))
+        )[KAPICallViewModel::class.java]
+
         binding.viewModel = callViewModel
         binding.recyclerviewCallApi.adapter = KDefaultRecyclerViewAdapter()
 

--- a/app/src/main/java/com/ama/algorithmmanagement/Activity/kDefault/KCallSolvedAlgorithmAct.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Activity/kDefault/KCallSolvedAlgorithmAct.kt
@@ -3,9 +3,12 @@ package com.ama.algorithmmanagement.Activity.kDefault
 import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import com.ama.algorithmmanagement.Adapter.KSolvedProblemsAdapter
+import com.ama.algorithmmanagement.Application.AMAApplication
 import com.ama.algorithmmanagement.Base.KBaseActivity
 import com.ama.algorithmmanagement.R
+import com.ama.algorithmmanagement.Repositories.RepositoryLocator
 import com.ama.algorithmmanagement.databinding.DefaultActivitySolvedProblemsBinding
+import com.ama.algorithmmanagement.utils.BaseViewModelFactory
 import com.ama.algorithmmanagement.viewmodel.kDefault.KAPICallViewModel
 
 class KCallSolvedAlgorithmAct :
@@ -15,7 +18,12 @@ class KCallSolvedAlgorithmAct :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        callViewModel = ViewModelProvider(this).get(KAPICallViewModel::class.java)
+
+        callViewModel = ViewModelProvider(
+            this,
+            BaseViewModelFactory(RepositoryLocator().getFakeRepository(AMAApplication.INSTANCE))
+        )[KAPICallViewModel::class.java]
+
         binding.viewModel = callViewModel
         binding.recyclerviewCallApi.adapter = KSolvedProblemsAdapter()
 

--- a/app/src/main/java/com/ama/algorithmmanagement/Base/BaseRepository.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Base/BaseRepository.kt
@@ -1,15 +1,14 @@
 package com.ama.algorithmmanagement.Base
 
 import com.ama.algorithmmanagement.Model.*
-import kotlinx.coroutines.delay
 
 interface BaseRepository {
 
-    suspend fun getSolvedProblems(userId: String): Problems
+    suspend fun getSolvedProblems(): Problems
 
-    suspend fun getSearchProblemList(problemId: String): Problems
+    suspend fun getSearchProblemList(problemId: Int): Problems
 
-    suspend fun getUserStats(userId: String): List<Stats>
+    suspend fun getUserStats(): List<Stats>
 
     suspend fun getBOJUserInfo(): List<ProblemStatus>
 
@@ -19,19 +18,19 @@ interface BaseRepository {
 
     fun getuserInfo(): UserInfo?
 
-    fun setDateInfo(): Result<Boolean>
+    fun setDateInfo(): Boolean
 
     fun getDateInfoObject(): DateInfoObject?
 
-    fun setIdeaInfo(url: String?, comment: String?, problemId: Int): Result<IdeaInfo>
+    fun setIdeaInfo(url: String?, comment: String?, problemId: Int): IdeaInfo
 
     fun getIdeaInfos(problemId: Int): IdeaInfos?
 
-    fun setComment(problemId: Int, comment: String): Result<CommentInfo>
+    fun setComment(problemId: Int, comment: String): CommentInfo
 
     fun getCommentObject(problemId: Int): CommentObject?
 
-    fun setChildComment(commentId: String, comment: String): Result<ChildCommentInfo>
+    fun setChildComment(commentId: String, comment: String): ChildCommentInfo
 
     fun getChildCommentObject(commentId: String): ChildCommentObject?
 
@@ -39,7 +38,15 @@ interface BaseRepository {
         problem: TaggedProblem,
         isShow: Boolean,
         tipComment: String?
-    ): Result<TipProblem>
+    ): TipProblem
 
     fun getTippingProblem(): TippingProblemObject?
+
+    fun modifyTippingProblem(
+        problemId: Int,
+        isShow: Boolean?,
+        comment: String?
+    ): Boolean
+
+    fun deleteTippingProblem( problemId: Int): Boolean
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/Base/BaseSharedPreference.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Base/BaseSharedPreference.kt
@@ -1,16 +1,19 @@
 package com.ama.algorithmmanagement.Base
 
 import com.ama.algorithmmanagement.Model.Problems
-import com.ama.algorithmmanagement.Model.TaggedProblem
 
 
 interface BaseSharedPreference {
 
-    fun getUserIdFromLocal(): String?
+    fun getUserId(): String?
 
-    fun deleteToUserId()
+    fun setAutoLoginCheck(check:Boolean)
 
-    fun setUserIdToLocal(userId: String)
+    fun getAutoLoginCheck(): Boolean
+
+    fun deleteUserId()
+
+    fun setUserId(userId: String)
 
     fun setTierType(tierType: Int)
 

--- a/app/src/main/java/com/ama/algorithmmanagement/Network/KAPIGenerator.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Network/KAPIGenerator.kt
@@ -1,13 +1,11 @@
 package com.ama.algorithmmanagement.Network
 
-import com.ama.algorithmmanagement.fake.FakeSharedPreference
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import timber.log.Timber
 
 object KAPIGenerator {
     private lateinit var retrofit: Retrofit

--- a/app/src/main/java/com/ama/algorithmmanagement/Network/KAPIService.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Network/KAPIService.kt
@@ -1,6 +1,9 @@
 package com.ama.algorithmmanagement.Network
 
-import com.ama.algorithmmanagement.Model.*
+import com.ama.algorithmmanagement.Model.BOJUser
+import com.ama.algorithmmanagement.Model.KProblemsOfClass
+import com.ama.algorithmmanagement.Model.Problems
+import com.ama.algorithmmanagement.Model.Stats
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query

--- a/app/src/main/java/com/ama/algorithmmanagement/Repositories/Repository.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Repositories/Repository.kt
@@ -2,8 +2,8 @@ package com.ama.algorithmmanagement.Repositories
 
 import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.*
-import com.ama.algorithmmanagement.Network.KAPIGenerator
 import com.ama.algorithmmanagement.Network.BaseNetworkService
+import com.ama.algorithmmanagement.Network.KAPIGenerator
 
 class Repository : BaseRepository {
 
@@ -30,16 +30,15 @@ class Repository : BaseRepository {
 
     }
 
-
-    override suspend fun getSolvedProblems(userId: String): Problems {
-        return networkService.getSolvedProblems(userId)
-    }
-
-    override suspend fun getSearchProblemList(problemId: String): Problems {
+    override suspend fun getSolvedProblems(): Problems {
         TODO("Not yet implemented")
     }
 
-    override suspend fun getUserStats(userId: String): List<Stats> {
+    override suspend fun getSearchProblemList(problemId: Int): Problems {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getUserStats(): List<Stats> {
         TODO("Not yet implemented")
     }
 
@@ -59,7 +58,7 @@ class Repository : BaseRepository {
         TODO("Not yet implemented")
     }
 
-    override fun setDateInfo(): Result<Boolean> {
+    override fun setDateInfo(): Boolean {
         TODO("Not yet implemented")
     }
 
@@ -67,7 +66,7 @@ class Repository : BaseRepository {
         TODO("Not yet implemented")
     }
 
-    override fun setIdeaInfo(url: String?, comment: String?, problemId: Int): Result<IdeaInfo> {
+    override fun setIdeaInfo(url: String?, comment: String?, problemId: Int): IdeaInfo {
         TODO("Not yet implemented")
     }
 
@@ -75,7 +74,7 @@ class Repository : BaseRepository {
         TODO("Not yet implemented")
     }
 
-    override fun setComment(problemId: Int, comment: String): Result<CommentInfo> {
+    override fun setComment(problemId: Int, comment: String): CommentInfo {
         TODO("Not yet implemented")
     }
 
@@ -83,7 +82,7 @@ class Repository : BaseRepository {
         TODO("Not yet implemented")
     }
 
-    override fun setChildComment(commentId: String, comment: String): Result<ChildCommentInfo> {
+    override fun setChildComment(commentId: String, comment: String): ChildCommentInfo {
         TODO("Not yet implemented")
     }
 
@@ -95,11 +94,23 @@ class Repository : BaseRepository {
         problem: TaggedProblem,
         isShow: Boolean,
         tipComment: String?
-    ): Result<TipProblem> {
+    ): TipProblem {
         TODO("Not yet implemented")
     }
 
     override fun getTippingProblem(): TippingProblemObject? {
+        TODO("Not yet implemented")
+    }
+
+    override fun modifyTippingProblem(
+        problemId: Int,
+        isShow: Boolean?,
+        comment: String?
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteTippingProblem(problemId: Int): Boolean {
         TODO("Not yet implemented")
     }
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/Repositories/RepositoryLocator.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/Repositories/RepositoryLocator.kt
@@ -1,8 +1,8 @@
 package com.ama.algorithmmanagement.Repositories
 
 import android.app.Application
-import com.ama.algorithmmanagement.Network.BaseNetworkService
 import com.ama.algorithmmanagement.fake.*
+import com.ama.algorithmmanagement.utils.DateUtils
 
 class RepositoryLocator {
 
@@ -19,12 +19,12 @@ class RepositoryLocator {
 
     fun getFakeRepository(app: Application): FakeRepository {
         if (!this::mFakeRepository.isInitialized) {
-            val fakeSharedPreference =  FakeSharedPreference(app)
             val firebaseReference =
-                FakeFirebaseReference(app, FakeFirebaseDataProvider(),fakeSharedPreference)
-            val networkService = FakeNetworkService(FakeNetWorkDataProvider(fakeSharedPreference))
+                FakeFirebaseReference(FakeFirebaseDataProvider(), DateUtils.createDate())
+            val networkService = FakeNetworkService(FakeNetWorkDataProvider())
 
-            mFakeRepository = FakeRepository(firebaseReference, networkService)
+            mFakeRepository =
+                FakeRepository(app, firebaseReference, networkService, FakeSharedPreference())
         }
 
         return mFakeRepository

--- a/app/src/main/java/com/ama/algorithmmanagement/fake/FakeFirebaseReference.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/fake/FakeFirebaseReference.kt
@@ -1,8 +1,6 @@
 package com.ama.algorithmmanagement.fake
 
-import android.app.Application
 import com.ama.algorithmmanagement.Model.*
-import com.ama.algorithmmanagement.R
 import timber.log.Timber
 
 class FakeFirebaseReference(

--- a/app/src/main/java/com/ama/algorithmmanagement/fake/FakeFirebaseReference.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/fake/FakeFirebaseReference.kt
@@ -1,40 +1,27 @@
 package com.ama.algorithmmanagement.fake
 
 import android.app.Application
-import com.ama.algorithmmanagement.Base.BaseSharedPreference
 import com.ama.algorithmmanagement.Model.*
 import com.ama.algorithmmanagement.R
-import com.ama.algorithmmanagement.utils.DateUtils
 import timber.log.Timber
-import java.lang.NullPointerException
 
 class FakeFirebaseReference(
-    private val mApp: Application,
     private val mFakeFirebaseDataProvider: FakeFirebaseDataProvider,
-    private val mSharedPrefUtils: BaseSharedPreference
+    private val mDate: String
 ) {
-
-    private val mUserId = mSharedPrefUtils.getUserIdFromLocal()
-    private val mTierType = mSharedPrefUtils.getTierType()
-    private val mDate = DateUtils.createDate()
-
 
     fun setUserInfo(userId: String, userPw: String, fcmToken: String?) {
         val userList = mFakeFirebaseDataProvider.userSnapShot
-
         userList.add(UserInfo(userId, userPw, fcmToken))
-
-        mSharedPrefUtils.setUserIdToLocal(userId)
     }
 
-    fun getUserInfo(): UserInfo? {
+    fun getUserInfo(userId: String?): UserInfo? {
         val userList = mFakeFirebaseDataProvider.userSnapShot
         for (userInfo in userList) {
-            if (userInfo.userId == mUserId) {
+            if (userInfo.userId == userId) {
                 return userInfo
             }
         }
-
         return null
     }
 
@@ -51,35 +38,24 @@ class FakeFirebaseReference(
         return false
     }
 
-    fun setDateInfo(): Result<Boolean> {
+    fun setDateInfo(userId: String): Boolean {
         val dateInfo = DateInfo(mDate)
 
-        if (mUserId == null) {
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "userId"
-                    )
-                )
-            )
-        }
-
         for (dateInfos in mFakeFirebaseDataProvider.dateSnapShot) {
-            if (dateInfos.userId == mUserId) {
+            if (dateInfos.userId == userId) {
                 dateInfos.dateList.add(dateInfo)
-                return Result.success(true)
+                return true
             }
         }
 
-        val dateInfos = DateInfoObject(1, mUserId, mutableListOf(dateInfo))
+        val dateInfos = DateInfoObject(1, userId, mutableListOf(dateInfo))
         mFakeFirebaseDataProvider.dateSnapShot.add(dateInfos)
-        return Result.success(true)
+        return true
     }
 
-    fun getDateInfos(): DateInfoObject? {
+    fun getDateInfos(userId: String?): DateInfoObject? {
         for (dateInfos in mFakeFirebaseDataProvider.dateSnapShot) {
-            if (dateInfos.userId == mUserId) {
+            if (dateInfos.userId == userId) {
                 return dateInfos
             }
         }
@@ -87,90 +63,67 @@ class FakeFirebaseReference(
     }
 
 
-    fun setIdeaInfo(url: String?, comment: String?, problemId: Int): Result<IdeaInfo> {
-        if (mUserId == null) {
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "userId"
-                    )
-                )
-            )
-        }
+    fun setIdeaInfo(
+        userId: String,
+        url: String?,
+        comment: String?,
+        problemId: Int
+    ): IdeaInfo {
 
         val ideaInfo = IdeaInfo(url, comment, mDate)
         val ideaInfos = IdeaInfos(1, problemId, mutableListOf(ideaInfo))
 
         for (ideaObject in mFakeFirebaseDataProvider.ideaSnapShot) {
-            if (ideaObject.userId == mUserId) {
+            if (ideaObject.userId == userId) {
 
                 for (ideainfos in ideaObject.ideaInfosList) {
                     if (ideainfos.problemId == problemId) {
                         ideainfos.ideaList.add(ideaInfo)
-                        return Result.success(ideaInfo)
+                        return ideaInfo
                     }
                 }
 
                 ideaObject.ideaInfosList.add(ideaInfos)
-                return Result.success(ideaInfo)
+                return ideaInfo
             }
         }
 
-        val ideaObject = IdeaObject(mUserId, mutableListOf(ideaInfos))
+        val ideaObject = IdeaObject(userId, mutableListOf(ideaInfos))
         mFakeFirebaseDataProvider.ideaSnapShot.add(ideaObject)
 
-        return Result.success(ideaInfo)
+        return ideaInfo
     }
 
-    fun getIdeaInfos(problemId: Int): IdeaInfos? {
+    fun getIdeaInfos(userId: String?, problemId: Int): IdeaInfos? {
         for (userIdeaInfo in mFakeFirebaseDataProvider.ideaSnapShot) {
-            if (userIdeaInfo.userId == mUserId) {
+            if (userIdeaInfo.userId == userId) {
 
                 for (ideaInfos in userIdeaInfo.ideaInfosList) {
                     if (ideaInfos.problemId == problemId) {
                         return ideaInfos
                     }
                 }
-
             }
         }
         return null
     }
 
-    fun setComment(problemId: Int, comment: String): Result<CommentInfo> {
-        if (mUserId == null) {
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "userId"
-                    )
-                )
-            )
-        }
-
-        if (mTierType == null) {
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "tierType"
-                    )
-                )
-            )
-        }
-
+    fun setComment(
+        userId: String,
+        tierType: Int,
+        problemId: Int,
+        comment: String
+    ): CommentInfo {
         val commentId = "RandomNumber"
 
         val newCommentInfo =
-            CommentInfo(commentId, mUserId, mTierType, comment, mDate, 0)
+            CommentInfo(commentId, userId, tierType, comment, mDate, 0)
 
         for (commentObject in mFakeFirebaseDataProvider.commentSnapShot) {
             if (commentObject.problemId == problemId) {
                 commentObject.commentList.add(newCommentInfo)
 
-                return Result.success(newCommentInfo)
+                return newCommentInfo
 
             }
         }
@@ -179,7 +132,7 @@ class FakeFirebaseReference(
 
         mFakeFirebaseDataProvider.commentSnapShot.add(commentObject)
 
-        return Result.success(newCommentInfo)
+        return newCommentInfo
     }
 
     fun getCommentObject(problemId: Int): CommentObject? {
@@ -188,46 +141,27 @@ class FakeFirebaseReference(
                 return commentinfo
             }
         }
-
         return null
     }
 
-    fun setChildComment(commentId: String, comment: String): Result<ChildCommentInfo> {
-        if (mUserId == null)
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "userId"
-                    )
-                )
-            )
-
-        if (mTierType == null) {
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "tierType"
-                    )
-                )
-            )
-        }
-
-        val childCommentInfo = ChildCommentInfo(mUserId, mTierType, comment, mDate)
-
+    fun setChildComment(
+        userId: String,
+        tierType: Int,
+        commentId: String,
+        comment: String
+    ): ChildCommentInfo {
+        val childCommentInfo = ChildCommentInfo(userId, tierType, comment, mDate)
 
         for (childCommentObject in mFakeFirebaseDataProvider.childCommentSnapShot) {
             if (childCommentObject.commentId == commentId) {
                 childCommentObject.commentChildList.add(childCommentInfo)
-                return Result.success(childCommentInfo)
+                return childCommentInfo
             }
         }
-
         val childCommentObject = ChildCommentObject(1, commentId, mutableListOf(childCommentInfo))
         mFakeFirebaseDataProvider.childCommentSnapShot.add(childCommentObject)
 
-        return Result.success(childCommentInfo)
+        return childCommentInfo
     }
 
 
@@ -245,43 +179,37 @@ class FakeFirebaseReference(
     }
 
     fun setTippingProblem(
+        userId: String,
         problem: TaggedProblem,
         isShow: Boolean,
         tipComment: String?
-    ): Result<TipProblem> {
-        if (mUserId == null) {
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "userId"
-                    )
-                )
-            )
-        }
+    ): TipProblem {
 
         val tipProblem = TipProblem(problem, isShow, tipComment, mDate)
 
         for (tipProblemObject in mFakeFirebaseDataProvider.tipProblemSnapShot) {
-            if (tipProblemObject.userId == mUserId) {
+            if (tipProblemObject.userId == userId) {
                 tipProblemObject.problemList.add(tipProblem)
-                return Result.success(tipProblem)
+                return tipProblem
             }
         }
 
-        val tipProblemObject = TippingProblemObject(1, mUserId, mutableListOf(tipProblem))
+        val tipProblemObject = TippingProblemObject(
+            1,
+            userId, mutableListOf(tipProblem)
+        )
         mFakeFirebaseDataProvider.tipProblemSnapShot.add(tipProblemObject)
 
-        return Result.success(tipProblem)
+        return tipProblem
     }
 
-    fun getTippingProblemObject(): TippingProblemObject? {
-        if (mUserId == null) {
+    fun getTippingProblemObject(userId: String?): TippingProblemObject? {
+        if (userId == null) {
             return null
         }
 
         for (tipProblemObject in mFakeFirebaseDataProvider.tipProblemSnapShot) {
-            if (tipProblemObject.userId == mUserId) {
+            if (tipProblemObject.userId == userId) {
                 return tipProblemObject
             }
         }
@@ -289,22 +217,14 @@ class FakeFirebaseReference(
     }
 
     fun modifyTippingProblem(
+        userId: String,
         problemId: Int,
         isShow: Boolean?,
         comment: String?
-    ): Result<Boolean> {
-        if (mUserId == null)
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "userId"
-                    )
-                )
-            )
+    ): Boolean {
 
         for (tipProblemObject in mFakeFirebaseDataProvider.tipProblemSnapShot) {
-            if (tipProblemObject.userId == mUserId) {
+            if (tipProblemObject.userId == userId) {
 
                 for (tipProblem in tipProblemObject.problemList.withIndex()) {
                     if (tipProblem.value.problem.problemId == problemId) {
@@ -314,37 +234,28 @@ class FakeFirebaseReference(
                         if (comment != null) {
                             tipProblem.value.tipComment = comment
                         }
-                        return Result.success(true)
+                        return true
                     }
                 }
             }
         }
 
-        return Result.success(false)
+        return true
     }
 
-    fun deleteTippingProblem(problemId: Int): Result<Boolean> {
-        if (mUserId == null)
-            return Result.failure(
-                NullPointerException(
-                    mApp.getString(
-                        R.string.objectIsNull,
-                        "userId"
-                    )
-                )
-            )
+    fun deleteTippingProblem(userId: String?, problemId: Int): Boolean {
 
         for (tipProblemObject in mFakeFirebaseDataProvider.tipProblemSnapShot) {
-            if (tipProblemObject.userId == mUserId) {
+            if (tipProblemObject.userId == userId) {
 
                 for (tipProblem in tipProblemObject.problemList.withIndex()) {
                     if (tipProblem.value.problem.problemId == problemId) {
                         tipProblemObject.problemList.removeAt(tipProblem.index)
-                        return Result.success(true)
+                        return true
                     }
                 }
             }
         }
-        return Result.success(false)
+        return true
     }
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/fake/FakeNetWorkDataProvider.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/fake/FakeNetWorkDataProvider.kt
@@ -2,7 +2,7 @@ package com.ama.algorithmmanagement.fake
 
 import com.ama.algorithmmanagement.Model.*
 
-class FakeNetWorkDataProvider(private val mFakeSharedPreference: FakeSharedPreference) {
+class FakeNetWorkDataProvider {
 
     fun getProblem(problemId: Int): TaggedProblem {
         return TaggedProblem(
@@ -56,7 +56,6 @@ class FakeNetWorkDataProvider(private val mFakeSharedPreference: FakeSharedPrefe
             }
         )
     }
-
 
     fun getStatsList(): List<Stats> {
         return MutableList<Stats>(20) {

--- a/app/src/main/java/com/ama/algorithmmanagement/fake/FakeNetworkService.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/fake/FakeNetworkService.kt
@@ -1,6 +1,9 @@
 package com.ama.algorithmmanagement.fake
 
-import com.ama.algorithmmanagement.Model.*
+import com.ama.algorithmmanagement.Model.ProblemStatus
+import com.ama.algorithmmanagement.Model.Problems
+import com.ama.algorithmmanagement.Model.Stats
+import com.ama.algorithmmanagement.Model.TaggedProblem
 import com.ama.algorithmmanagement.Network.BaseNetworkService
 import kotlinx.coroutines.delay
 

--- a/app/src/main/java/com/ama/algorithmmanagement/fake/FakeRepository.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/fake/FakeRepository.kt
@@ -1,32 +1,50 @@
 package com.ama.algorithmmanagement.fake
 
+import android.app.Application
 import com.ama.algorithmmanagement.Base.BaseRepository
+import com.ama.algorithmmanagement.Base.BaseSharedPreference
 import com.ama.algorithmmanagement.Model.*
 import com.ama.algorithmmanagement.Network.BaseNetworkService
+import com.ama.algorithmmanagement.R
+import java.lang.NullPointerException
 
 class FakeRepository(
+    private val mApp: Application,
     private val mFakeFirebaseReference: FakeFirebaseReference,
-    private val mBaseNetworkService: BaseNetworkService
+    private val mBaseNetworkService: BaseNetworkService,
+    private val mSharedPrefUtils: BaseSharedPreference,
 ) : BaseRepository {
 
-    override suspend fun getSolvedProblems(userId: String): Problems {
-        return mBaseNetworkService.getSolvedProblems(userId)
+    private val mUserId = mSharedPrefUtils.getUserId()
+    private val mTierType = mSharedPrefUtils.getTierType()
+
+    override suspend fun getSolvedProblems(): Problems {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+
+        return mBaseNetworkService.getSolvedProblems(mUserId)
     }
 
-    override suspend fun getSearchProblemList(problemId: String): Problems {
-        TODO("Not yet implemented")
+    override suspend fun getSearchProblemList(problemId: Int): Problems {
+        return mBaseNetworkService.getSearchProblemList(problemId)
     }
 
-    override suspend fun getUserStats(userId: String): List<Stats> {
-        TODO("Not yet implemented")
+    override suspend fun getUserStats(): List<Stats> {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+
+        return mBaseNetworkService.getUserStats(mUserId)
     }
 
     override suspend fun getBOJUserInfo(): List<ProblemStatus> {
-        TODO("Not yet implemented")
+        return mBaseNetworkService.getBOJUserInfo()
     }
 
     override fun setUserInfo(userId: String, password: String, fcmToken: String?) {
         mFakeFirebaseReference.setUserInfo(userId, password, fcmToken)
+        mSharedPrefUtils.setUserId(userId)
     }
 
     override fun checkUserInfo(userId: String, password: String): Boolean {
@@ -34,35 +52,57 @@ class FakeRepository(
     }
 
     override fun getuserInfo(): UserInfo? {
-        return mFakeFirebaseReference.getUserInfo()
+        return mFakeFirebaseReference.getUserInfo(mUserId)
     }
 
-    override fun setDateInfo() :Result<Boolean> {
-       return mFakeFirebaseReference.setDateInfo()
+    override fun setDateInfo(): Boolean {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+
+        return mFakeFirebaseReference.setDateInfo(mUserId)
     }
 
     override fun getDateInfoObject(): DateInfoObject? {
-        return mFakeFirebaseReference.getDateInfos()
+        return mFakeFirebaseReference.getDateInfos(mUserId)
     }
 
-    override fun setIdeaInfo(url: String?, comment: String?, problemId: Int): Result<IdeaInfo> {
-        return mFakeFirebaseReference.setIdeaInfo(url, comment, problemId)
+    override fun setIdeaInfo(url: String?, comment: String?, problemId: Int): IdeaInfo {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+
+        return mFakeFirebaseReference.setIdeaInfo(mUserId, url, comment, problemId)
     }
 
     override fun getIdeaInfos(problemId: Int): IdeaInfos? {
-        return mFakeFirebaseReference.getIdeaInfos(problemId)
+        return mFakeFirebaseReference.getIdeaInfos(mUserId, problemId)
     }
 
-    override fun setComment(problemId: Int, comment: String): Result<CommentInfo> {
-        return mFakeFirebaseReference.setComment(problemId, comment)
+    override fun setComment(problemId: Int, comment: String): CommentInfo {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+        if (mTierType == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "mTierType"))
+        }
+
+        return mFakeFirebaseReference.setComment(mUserId, mTierType, problemId, comment)
     }
 
     override fun getCommentObject(problemId: Int): CommentObject? {
-       return mFakeFirebaseReference.getCommentObject(problemId)
+        return mFakeFirebaseReference.getCommentObject(problemId)
     }
 
-    override fun setChildComment(commentId: String, comment: String): Result<ChildCommentInfo> {
-        return mFakeFirebaseReference.setChildComment(commentId, comment)
+    override fun setChildComment(commentId: String, comment: String): ChildCommentInfo {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+        if (mTierType == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "mTierType"))
+        }
+
+        return mFakeFirebaseReference.setChildComment(mUserId, mTierType, commentId, comment)
     }
 
     override fun getChildCommentObject(commentId: String): ChildCommentObject? {
@@ -73,12 +113,36 @@ class FakeRepository(
         problem: TaggedProblem,
         isShow: Boolean,
         tipComment: String?
-    ): Result<TipProblem> {
-        return mFakeFirebaseReference.setTippingProblem(problem, isShow, tipComment)
+    ): TipProblem {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+
+        return mFakeFirebaseReference.setTippingProblem(mUserId, problem, isShow, tipComment)
     }
 
     override fun getTippingProblem(): TippingProblemObject? {
-        return mFakeFirebaseReference.getTippingProblemObject()
+        return mFakeFirebaseReference.getTippingProblemObject(mUserId)
+    }
+
+    override fun modifyTippingProblem(
+        problemId: Int,
+        isShow: Boolean?,
+        comment: String?
+    ): Boolean {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+
+        return mFakeFirebaseReference.modifyTippingProblem(mUserId, problemId, isShow, comment)
+    }
+
+    override fun deleteTippingProblem(problemId: Int): Boolean {
+        if (mUserId == null) {
+            throw NullPointerException(mApp.getString(R.string.objectIsNull, "userId"))
+        }
+
+        return mFakeFirebaseReference.deleteTippingProblem(mUserId, problemId)
     }
 
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/fake/FakeRepository.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/fake/FakeRepository.kt
@@ -6,7 +6,6 @@ import com.ama.algorithmmanagement.Base.BaseSharedPreference
 import com.ama.algorithmmanagement.Model.*
 import com.ama.algorithmmanagement.Network.BaseNetworkService
 import com.ama.algorithmmanagement.R
-import java.lang.NullPointerException
 
 class FakeRepository(
     private val mApp: Application,

--- a/app/src/main/java/com/ama/algorithmmanagement/fake/FakeSharedPreference.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/fake/FakeSharedPreference.kt
@@ -1,26 +1,32 @@
 package com.ama.algorithmmanagement.fake
 
-import android.app.Application
 import com.ama.algorithmmanagement.Base.BaseSharedPreference
 import com.ama.algorithmmanagement.Model.Problems
 import com.google.gson.Gson
-import kotlin.collections.HashMap
 
-class FakeSharedPreference(private val mApp: Application) : BaseSharedPreference {
+class FakeSharedPreference : BaseSharedPreference {
     private val fakeMap = HashMap<SharedKey, Any>()
 
-    override fun setUserIdToLocal(userId: String) {
+    override fun setUserId(userId: String) {
         fakeMap[SharedKey.USERID] = userId
     }
 
-    override fun getUserIdFromLocal(): String? {
+    override fun getUserId(): String? {
         return fakeMap[SharedKey.USERID] as? String
     }
 
-    override fun deleteToUserId() {
-        fakeMap.remove(SharedKey.USERID)
+    override fun setAutoLoginCheck(check: Boolean) {
+        fakeMap[SharedKey.AUTO_LOGIN] = check
     }
 
+    override fun getAutoLoginCheck(): Boolean {
+        val check = fakeMap[SharedKey.AUTO_LOGIN] as? Boolean
+        return check ?: false
+    }
+
+    override fun deleteUserId() {
+        fakeMap.remove(SharedKey.USERID)
+    }
 
     override fun setTierType(tierType: Int) {
         fakeMap[SharedKey.TIER] = tierType
@@ -47,12 +53,10 @@ class FakeSharedPreference(private val mApp: Application) : BaseSharedPreference
     }
 
     override fun setSolvedProblems(solvedProblem: Problems) {
-        if (!fakeMap.containsKey(SharedKey.SOLVED)) {
-            val gson = Gson()
-            val jsonObj = gson.toJson(solvedProblem)
+        val gson = Gson()
+        val jsonObj = gson.toJson(solvedProblem)
 
-            fakeMap[SharedKey.SOLVED] = jsonObj
-        }
+        fakeMap[SharedKey.SOLVED] = jsonObj
     }
 
     override fun getSolvedProblems(): Problems? {
@@ -66,9 +70,8 @@ class FakeSharedPreference(private val mApp: Application) : BaseSharedPreference
         fakeMap.remove(SharedKey.SOLVED)
     }
 
-
     enum class SharedKey {
-        SOLVED, USERID, TIER, TOKEN
+        SOLVED, USERID, TIER, TOKEN, AUTO_LOGIN
     }
 
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/utils/BaseViewModelFactory.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/utils/BaseViewModelFactory.kt
@@ -1,0 +1,29 @@
+package com.ama.algorithmmanagement.utils
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.ama.algorithmmanagement.Base.BaseRepository
+import java.lang.reflect.InvocationTargetException
+
+class BaseViewModelFactory(private val repository: BaseRepository) :
+    ViewModelProvider.NewInstanceFactory() {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (ViewModel::class.java.isAssignableFrom(modelClass)) {
+            try {
+                return modelClass.getConstructor(BaseRepository::class.java)
+                    .newInstance(repository)
+
+            } catch (e: NoSuchMethodException) {
+                throw RuntimeException("Cannot create an instance of $modelClass", e)
+            } catch (e: IllegalAccessException) {
+                throw RuntimeException("Cannot create an instance of $modelClass", e)
+            } catch (e: InstantiationException) {
+                throw RuntimeException("Cannot create an instance of $modelClass", e)
+            } catch (e: InvocationTargetException) {
+                throw RuntimeException("Cannot create an instance of $modelClass", e)
+            }
+        }
+        return super.create(modelClass)
+    }
+}

--- a/app/src/main/java/com/ama/algorithmmanagement/utils/Result.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/utils/Result.kt
@@ -1,6 +1,0 @@
-package com.ama.algorithmmanagement.utils
-
-sealed class Result<out T : Any> {
-    data class Success<out T : Any>(val isSuccess: Boolean) : Result<T>()
-    data class Error<out T : Any>(val exeception: Exception) : Result<T>()
-}

--- a/app/src/main/java/com/ama/algorithmmanagement/utils/SharedPrefUtils.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/utils/SharedPrefUtils.kt
@@ -10,19 +10,27 @@ class SharedPrefUtils(private val mContext: Context) : BaseSharedPreference {
     private val mSharedPreferences = mContext.getSharedPreferences("AMA_pref", Context.MODE_PRIVATE)
 
 
-    override fun getUserIdFromLocal(): String? {
+    override fun getUserId(): String? {
         Timber.e(mSharedPreferences.getString(mContext.getString(R.string.prefGetUserId), null))
         return mSharedPreferences.getString(mContext.getString(R.string.prefGetUserId), null)
     }
 
-    override fun deleteToUserId() {
+    override fun setAutoLoginCheck(check: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAutoLoginCheck(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteUserId() {
         with(mSharedPreferences.edit()) {
             remove(mContext.getString(R.string.prefGetUserId))
             commit()
         }
     }
 
-    override fun setUserIdToLocal(userId: String) {
+    override fun setUserId(userId: String) {
         with(mSharedPreferences.edit()) {
             putString(mContext.getString(R.string.prefGetUserId), userId)
             commit()

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/kDefault/KAPICallViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/kDefault/KAPICallViewModel.kt
@@ -43,10 +43,7 @@ class KAPICallViewModel(private val app: Application) : AndroidViewModel(app) {
     private fun getSolvedProblems() {
         viewModelScope.launch {
             try {
-
-                _solvedAlgorithms.value = repository.getSolvedProblems(
-                    app.getString(R.string.solvedProblemUserId, "skjh0818")
-                )
+                _solvedAlgorithms.value = repository.getSolvedProblems()
             } catch (e: Exception) {
                 Timber.e(e.message.toString())
             }

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/kDefault/KAPICallViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/kDefault/KAPICallViewModel.kt
@@ -1,18 +1,15 @@
 package com.ama.algorithmmanagement.viewmodel.kDefault
 
-import android.app.Application
 import androidx.lifecycle.*
+import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.KProblemsOfClass
 import com.ama.algorithmmanagement.Model.Problems
 import com.ama.algorithmmanagement.Model.TaggedProblem
 import com.ama.algorithmmanagement.Network.KAPIGenerator
-import com.ama.algorithmmanagement.R
-import com.ama.algorithmmanagement.Repositories.RepositoryLocator
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-class KAPICallViewModel(private val app: Application) : AndroidViewModel(app) {
-    private val repository = RepositoryLocator().getRepository()
+class KAPICallViewModel(private val mRepository: BaseRepository) : ViewModel() {
 
     private val _classList = MutableLiveData<List<KProblemsOfClass>>()
     val classList: LiveData<List<KProblemsOfClass>>
@@ -43,7 +40,7 @@ class KAPICallViewModel(private val app: Application) : AndroidViewModel(app) {
     private fun getSolvedProblems() {
         viewModelScope.launch {
             try {
-                _solvedAlgorithms.value = repository.getSolvedProblems()
+                _solvedAlgorithms.value = mRepository.getSolvedProblems()
             } catch (e: Exception) {
                 Timber.e(e.message.toString())
             }

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestChildCommentViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestChildCommentViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.ChildCommentInfo
 import com.ama.algorithmmanagement.Model.ChildCommentObject
-import timber.log.Timber
 
 class TestChildCommentViewModel(private var mRepository: BaseRepository) : ViewModel() {
     var mChildCommentObject: ChildCommentObject? = null

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestChildCommentViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestChildCommentViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.ChildCommentInfo
 import com.ama.algorithmmanagement.Model.ChildCommentObject
-import com.ama.algorithmmanagement.utils.combineWith
 import timber.log.Timber
 
 class TestChildCommentViewModel(private var mRepository: BaseRepository) : ViewModel() {
@@ -27,22 +26,8 @@ class TestChildCommentViewModel(private var mRepository: BaseRepository) : ViewM
     }
 
     fun saveChildComment() {
-//        val check =
-//            combineWith(mCommentId, mComment) { id, comment -> id != null && comment != null }
-//
-//        check.value?.let { result ->
-//            {
-//                if (result) {
-                    mRepository.setChildComment(mCommentId.value!!, mComment.value!!).onSuccess {
-                        if(!childCommentInfoList.contains(it)){
-                            childCommentInfoList.add(it)
-                        }
-                    }.onFailure {
-                        Timber.e(it)
-                    }
-//                }
-//            }
-//        }
+        val comment = mRepository.setChildComment(mCommentId.value!!, mComment.value!!)
+        childCommentInfoList.add(comment)
     }
 
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestCommentViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestCommentViewModel.kt
@@ -3,8 +3,8 @@ package com.ama.algorithmmanagement.viewmodel.test
 import androidx.databinding.ObservableArrayList
 import androidx.lifecycle.MutableLiveData
 import com.ama.algorithmmanagement.Base.BaseRepository
-import com.ama.algorithmmanagement.Model.*
-import com.ama.algorithmmanagement.utils.combineWith
+import com.ama.algorithmmanagement.Model.CommentInfo
+import com.ama.algorithmmanagement.Model.CommentObject
 import timber.log.Timber
 
 
@@ -27,21 +27,8 @@ class TestCommentViewModel(private var mRepository: BaseRepository) {
     }
 
     fun saveComment() {
-//        val checkData =
-//            combineWith(mProblemId, mComment) { id, comment -> id != null && comment != null }
-//
-//        checkData.value?.let { isPossible ->
-//            if (isPossible) {
-                mRepository.setComment(mProblemId.value!!, mComment.value!!)
-                    .onSuccess { commentInfo ->
-                        if (!commentInfoList.contains(commentInfo)) {
-                            commentInfoList.add(commentInfo)
-                        }
-                    }.onFailure {
-                        Timber.e(it)
-                    }
-//            }
-//        }
+        val comment = mRepository.setComment(mProblemId.value!!, mComment.value!!)
+        commentInfoList.add(comment)
     }
 
 

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestCommentViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestCommentViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.CommentInfo
 import com.ama.algorithmmanagement.Model.CommentObject
-import timber.log.Timber
 
 
 class TestCommentViewModel(private var mRepository: BaseRepository) {

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestIdeaViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestIdeaViewModel.kt
@@ -4,7 +4,6 @@ import androidx.databinding.ObservableArrayList
 import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.IdeaInfo
 import com.ama.algorithmmanagement.Model.IdeaInfos
-import timber.log.Timber
 
 
 class TestIdeaViewModel(private var repository: BaseRepository) {

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestIdeaViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestIdeaViewModel.kt
@@ -1,10 +1,9 @@
 package com.ama.algorithmmanagement.viewmodel.test
 
 import androidx.databinding.ObservableArrayList
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import com.ama.algorithmmanagement.Base.BaseRepository
-import com.ama.algorithmmanagement.Model.*
+import com.ama.algorithmmanagement.Model.IdeaInfo
+import com.ama.algorithmmanagement.Model.IdeaInfos
 import timber.log.Timber
 
 
@@ -13,11 +12,8 @@ class TestIdeaViewModel(private var repository: BaseRepository) {
     var ideaLst = ObservableArrayList<IdeaInfo>()
 
     fun setIdeaInfo(url: String?, comment: String?, problemId: Int) {
-        repository.setIdeaInfo(url, comment, problemId).onSuccess {
-
-        }.onFailure {
-            Timber.e(it)
-        }
+        val idea = repository.setIdeaInfo(url, comment, problemId)
+        ideaLst.add(idea)
     }
 
     fun getIdeaInfos(problemId: Int) {

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestTipViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestTipViewModel.kt
@@ -5,7 +5,6 @@ import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.TaggedProblem
 import com.ama.algorithmmanagement.Model.TipProblem
 import com.ama.algorithmmanagement.Model.TippingProblemObject
-import timber.log.Timber
 
 
 class TestTipViewModel(private var repository: BaseRepository) {

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestTipViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestTipViewModel.kt
@@ -1,33 +1,27 @@
 package com.ama.algorithmmanagement.viewmodel.test
 
 import androidx.databinding.ObservableArrayList
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import com.ama.algorithmmanagement.Base.BaseRepository
-import com.ama.algorithmmanagement.Model.*
+import com.ama.algorithmmanagement.Model.TaggedProblem
+import com.ama.algorithmmanagement.Model.TipProblem
+import com.ama.algorithmmanagement.Model.TippingProblemObject
 import timber.log.Timber
 
 
 class TestTipViewModel(private var repository: BaseRepository) {
     val tipProblems = ObservableArrayList<TipProblem>()
-
-    var tipProbleObject :TippingProblemObject? =null
+    var tipProbleObject: TippingProblemObject? = null
 
     fun setTippingProblem(
         problem: TaggedProblem,
         isShow: Boolean,
         tipComment: String?
     ) {
-        repository.setTippingProblem(problem, isShow, tipComment).onSuccess {
-            if (!tipProblems.contains(it)) {
-                tipProblems.add(it)
-            }
-        }.onFailure {
-            Timber.e(it)
-        }
+        val tip = repository.setTippingProblem(problem, isShow, tipComment)
+        tipProblems.add(tip)
     }
 
-    fun getTipProblemObject(){
+    fun initTipProblemObject() {
         tipProbleObject = repository.getTippingProblem()
     }
 

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestViewModel.kt
@@ -3,9 +3,9 @@ package com.ama.algorithmmanagement.viewmodel.test
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.ama.algorithmmanagement.Base.BaseRepository
-import com.ama.algorithmmanagement.Model.*
+import com.ama.algorithmmanagement.Model.DateInfoObject
+import com.ama.algorithmmanagement.Model.UserInfo
 import timber.log.Timber
-
 
 class TestViewModel(private var repository: BaseRepository) {
     private val _userId = MutableLiveData<String>()
@@ -36,11 +36,7 @@ class TestViewModel(private var repository: BaseRepository) {
     }
 
     fun setDateInfo() {
-        repository.setDateInfo().onSuccess {
-
-        }.onFailure {
-            Timber.e(it)
-        }
+        val date = repository.setDateInfo()
     }
 
     fun getDateInfoObejct() {

--- a/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/viewmodel/test/TestViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import com.ama.algorithmmanagement.Base.BaseRepository
 import com.ama.algorithmmanagement.Model.DateInfoObject
 import com.ama.algorithmmanagement.Model.UserInfo
-import timber.log.Timber
 
 class TestViewModel(private var repository: BaseRepository) {
     private val _userId = MutableLiveData<String>()

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseChildComment.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseChildComment.kt
@@ -1,10 +1,8 @@
 package com.ama.algorithmmanagement.fake
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.utils.DateUtils
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseChildComment.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseChildComment.kt
@@ -3,35 +3,39 @@ package com.ama.algorithmmanagement.fake
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.utils.DateUtils
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.IllegalStateException
 
 @RunWith(AndroidJUnit4::class)
 class FakeFirebaseChildComment {
     lateinit var fakeFirebaseReference: FakeFirebaseReference
     lateinit var fakeSharedPreference: FakeSharedPreference
+    lateinit var mUserId: String
+    var mTierType: Int = 0
 
     @Before
     fun init() {
-        fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference = FakeSharedPreference()
+        fakeSharedPreference.setUserId("skjh0818")
         fakeSharedPreference.setTierType(1)
+
+        mUserId = fakeSharedPreference.getUserId()!!
+        mTierType = fakeSharedPreference.getTierType()!!
 
         fakeFirebaseReference =
             FakeFirebaseReference(
-                ApplicationProvider.getApplicationContext(),
                 FakeFirebaseDataProvider(),
-                fakeSharedPreference
+                DateUtils.createDate()
             )
     }
 
     @Test
     fun getChildCommentObject() {
         //given
-        fakeFirebaseReference.setComment(1111, "parent Comment")
+        fakeFirebaseReference.setComment(mUserId, mTierType, 1111, "parent Comment")
 
         //intent로부터 commentId가 넘어옴
         //when
@@ -40,21 +44,17 @@ class FakeFirebaseChildComment {
         }
 
         //when
-        fakeFirebaseReference.setChildComment(commentId!!, "child Comment").onSuccess { isSuccess ->
+        fakeFirebaseReference.setChildComment(mUserId, mTierType, commentId!!, "child Comment")
+        val childCommentObject = fakeFirebaseReference.getChildCommentObject(commentId)
 
-            val childCommentObject = fakeFirebaseReference.getChildCommentObject(commentId)
-            //then
-            childCommentObject?.let {
-                assertEquals(it.commentId, commentId)
-                assertEquals(it.commentChildList[0].comment, "child Comment")
-                assertEquals(it.commentChildList[0].userId, "skjh0818")
-                assertEquals(it.commentChildList[0].tierType, 1)
-                assertEquals(it.commentChildList[0].date, DateUtils.createDate())
-            }
-        }.onFailure {
-            assertThrows(IllegalStateException::class.java) {
+        //then
+        childCommentObject?.let {
+            assertEquals(it.commentId, commentId)
+            assertEquals(it.commentChildList[0].comment, "child Comment")
+            assertEquals(it.commentChildList[0].userId, "skjh0818")
+            assertEquals(it.commentChildList[0].tierType, 1)
+            assertEquals(it.commentChildList[0].date, DateUtils.createDate())
 
-            }
         }
     }
 
@@ -67,19 +67,14 @@ class FakeFirebaseChildComment {
         }
 
         //then
-        fakeFirebaseReference.setChildComment(commentId!!, "child Comment").onSuccess { isSuccess ->
+        fakeFirebaseReference.setChildComment(mUserId, mTierType, commentId!!, "child Comment")
 
-        }.onFailure {
-            assertThrows(IllegalStateException::class.java) {
-
-            }
-        }
     }
 
     @Test
     fun getChildCommentObject_moreThanChildComment_returnChildCommentList() {
         //given
-        fakeFirebaseReference.setComment(1111, "parent Comment")
+        fakeFirebaseReference.setComment(mUserId, mTierType, 1111, "parent Comment")
 
         //when
         val commentId = fakeFirebaseReference.getCommentObject(1111)?.let { commentObject ->
@@ -87,18 +82,18 @@ class FakeFirebaseChildComment {
         }
 
         //then
-        fakeFirebaseReference.setChildComment(commentId!!, "child 1")
-        fakeFirebaseReference.setChildComment(commentId, "child 2")
-        fakeFirebaseReference.setChildComment(commentId, "child 3")
+        fakeFirebaseReference.setChildComment(mUserId, mTierType, commentId!!, "child 1")
+        fakeFirebaseReference.setChildComment(mUserId, mTierType, commentId, "child 2")
+        fakeFirebaseReference.setChildComment(mUserId, mTierType, commentId, "child 3")
 
         //when
         val childCommentObject = fakeFirebaseReference.getChildCommentObject(commentId)
 
         //then
-        assertEquals(childCommentObject?.commentId,"RandomNumber")
-        assertEquals(childCommentObject?.commentChildList?.get(0)?.comment,"child 1")
-        assertEquals(childCommentObject?.commentChildList?.get(1)?.comment,"child 2")
-        assertEquals(childCommentObject?.commentChildList?.get(2)?.comment,"child 3")
+        assertEquals(childCommentObject?.commentId, "RandomNumber")
+        assertEquals(childCommentObject?.commentChildList?.get(0)?.comment, "child 1")
+        assertEquals(childCommentObject?.commentChildList?.get(1)?.comment, "child 2")
+        assertEquals(childCommentObject?.commentChildList?.get(2)?.comment, "child 3")
 
     }
 }

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseComment.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseComment.kt
@@ -1,6 +1,5 @@
 package com.ama.algorithmmanagement.fake
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.utils.DateUtils
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseComment.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseComment.kt
@@ -3,31 +3,33 @@ package com.ama.algorithmmanagement.fake
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.utils.DateUtils
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.TestLifecycleApplication
-import java.lang.NullPointerException
 
 
 @RunWith(AndroidJUnit4::class)
 class FakeFirebaseComment {
     lateinit var fakeFirebaseReference: FakeFirebaseReference
     lateinit var fakeSharedPreference: FakeSharedPreference
-
+    lateinit var mUserId: String
+    var mTierType: Int =0
 
     @Before
     fun init() {
-        fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference = FakeSharedPreference()
+        fakeSharedPreference.setUserId("skjh0818")
         fakeSharedPreference.setTierType(1)
+
+        mUserId = fakeSharedPreference.getUserId()!!
+        mTierType = fakeSharedPreference.getTierType()!!
 
         fakeFirebaseReference =
             FakeFirebaseReference(
-                ApplicationProvider.getApplicationContext(),
+
                 FakeFirebaseDataProvider(),
-                fakeSharedPreference
+                DateUtils.createDate()
             )
     }
 
@@ -35,7 +37,7 @@ class FakeFirebaseComment {
     @Test
     fun getCommentObject() {
         //given
-        fakeFirebaseReference.setComment(1111, "이거 어떻게 풀어요?")
+        fakeFirebaseReference.setComment(mUserId,mTierType,1111, "이거 어떻게 풀어요?")
 
         //when
         val commentObject = fakeFirebaseReference.getCommentObject(1111)
@@ -54,8 +56,8 @@ class FakeFirebaseComment {
     @Test
     fun getCommentInfo_moreThanOneValue() {
         //given
-        fakeFirebaseReference.setComment(1111, "what?")
-        fakeFirebaseReference.setComment(2222, "how?")
+        fakeFirebaseReference.setComment(mUserId,mTierType,1111, "what?")
+        fakeFirebaseReference.setComment(mUserId,mTierType,2222, "how?")
 
         //when
         val object1 = fakeFirebaseReference.getCommentObject(1111)
@@ -74,8 +76,8 @@ class FakeFirebaseComment {
     @Test
     fun getCommentInfo_moreThanComment() {
         //given
-        fakeFirebaseReference.setComment(1111, "what?")
-        fakeFirebaseReference.setComment(1111, "why?")
+        fakeFirebaseReference.setComment(mUserId,mTierType,1111, "what?")
+        fakeFirebaseReference.setComment(mUserId,mTierType,1111, "why?")
 
         //when
         val object1 = fakeFirebaseReference.getCommentObject(1111)

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseDateInfo.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseDateInfo.kt
@@ -4,9 +4,9 @@ package com.ama.algorithmmanagement.fake
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.Model.DateInfo
-import org.junit.Assert.*
+import com.ama.algorithmmanagement.utils.DateUtils
+import org.junit.Assert.assertEquals
 import org.junit.Before
-
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -16,17 +16,19 @@ class FakeFirebaseDateInfo {
 
     lateinit var fakeFirebaseReference: FakeFirebaseReference
     lateinit var fakeSharedPreference: FakeSharedPreference
+    lateinit var mUserId: String
 
     @Before
     fun init() {
-        fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference = FakeSharedPreference()
+        fakeSharedPreference.setUserId("skjh0818")
+
+        mUserId = fakeSharedPreference.getUserId()!!
 
         fakeFirebaseReference =
             FakeFirebaseReference(
-                ApplicationProvider.getApplicationContext(),
                 FakeFirebaseDataProvider(),
-                fakeSharedPreference
+                DateUtils.createDate()
             )
     }
 
@@ -34,11 +36,11 @@ class FakeFirebaseDateInfo {
     @Test
     fun getDateInfos() {
         //given
-        fakeFirebaseReference.setDateInfo()
+        fakeFirebaseReference.setDateInfo(mUserId)
 
         //when
-        val dateInfos = fakeFirebaseReference.getDateInfos()
-        val dateInfoList = mutableListOf(DateInfo("2021.12.01"))
+        val dateInfos = fakeFirebaseReference.getDateInfos(mUserId)
+        val dateInfoList = mutableListOf(DateInfo(DateUtils.createDate()))
 
         //then
         assertEquals(dateInfos?.count, 1)

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseDateInfo.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseDateInfo.kt
@@ -1,7 +1,6 @@
 package com.ama.algorithmmanagement.fake
 
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.Model.DateInfo
 import com.ama.algorithmmanagement.utils.DateUtils

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseIdeaInfo.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseIdeaInfo.kt
@@ -1,6 +1,5 @@
 package com.ama.algorithmmanagement.fake
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.utils.DateUtils
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseIdeaInfo.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseIdeaInfo.kt
@@ -2,10 +2,10 @@ package com.ama.algorithmmanagement.fake
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ama.algorithmmanagement.Model.IdeaInfo
-import org.junit.Assert.*
+import com.ama.algorithmmanagement.utils.DateUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
-
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -15,17 +15,19 @@ class FakeFirebaseIdeaInfo {
 
     lateinit var fakeFirebaseReference: FakeFirebaseReference
     lateinit var fakeSharedPreference: FakeSharedPreference
+    lateinit var mUserId: String
 
     @Before
     fun init() {
-        fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference = FakeSharedPreference()
+        fakeSharedPreference.setUserId("skjh0818")
+
+        mUserId = fakeSharedPreference.getUserId()!!
 
         fakeFirebaseReference =
             FakeFirebaseReference(
-                ApplicationProvider.getApplicationContext(),
                 FakeFirebaseDataProvider(),
-                fakeSharedPreference
+                DateUtils.createDate()
             )
     }
 
@@ -33,28 +35,28 @@ class FakeFirebaseIdeaInfo {
     @Test
     fun getIdeaInfos_exist_userId_returnIdeaInfos() {
         //given
-        fakeFirebaseReference.setIdeaInfo(null, "이건 dp로 풀어야해", 1111)
+        fakeFirebaseReference.setIdeaInfo(mUserId,null, "이건 dp로 풀어야해", 1111)
 
         //when
-        val ideaInfos = fakeFirebaseReference.getIdeaInfos(1111)
+        val ideaInfos = fakeFirebaseReference.getIdeaInfos(mUserId,1111)
         val ideaInfo = ideaInfos?.ideaList?.get(0)
 
         //then
         assertEquals(ideaInfos?.problemId, 1111)
         assertEquals(ideaInfos?.ideaList?.get(0)?.url, null)
         assertEquals(ideaInfos?.ideaList?.get(0)?.comment, "이건 dp로 풀어야해")
-        assertEquals(ideaInfos?.ideaList?.get(0)?.date, "2021.12.01")
+        assertEquals(ideaInfos?.ideaList?.get(0)?.date, DateUtils.createDate())
 
     }
 
     @Test
     fun getIdeaInfos_exist_sameProblemIdea_returnIdeaInfos() {
         // given
-        fakeFirebaseReference.setIdeaInfo(null, "이건 dp로 풀어야해", 1111)
-        fakeFirebaseReference.setIdeaInfo(null, "이건 완탐으로 풀어야해", 1111)
+        fakeFirebaseReference.setIdeaInfo(mUserId,null, "이건 dp로 풀어야해", 1111)
+        fakeFirebaseReference.setIdeaInfo(mUserId,null, "이건 완탐으로 풀어야해", 1111)
 
         //when
-        val ideaInfos = fakeFirebaseReference.getIdeaInfos(1111)
+        val ideaInfos = fakeFirebaseReference.getIdeaInfos(mUserId,1111)
 
         //then
         assertEquals(ideaInfos?.ideaList?.get(0)?.comment, "이건 dp로 풀어야해")
@@ -65,12 +67,12 @@ class FakeFirebaseIdeaInfo {
     @Test
     fun getIdeaInfos_exist_differentProblemIdea_returnIdeaInfos() {
         //given
-        fakeFirebaseReference.setIdeaInfo(null, "이건 dp로 풀어야해", 1234)
-        fakeFirebaseReference.setIdeaInfo(null, "이건 완탐으로 풀어야해", 4321)
+        fakeFirebaseReference.setIdeaInfo(mUserId,null, "이건 dp로 풀어야해", 1234)
+        fakeFirebaseReference.setIdeaInfo(mUserId,null, "이건 완탐으로 풀어야해", 4321)
 
         //when
-        val ideaInfos1 = fakeFirebaseReference.getIdeaInfos(1234)
-        val ideaInfos2 = fakeFirebaseReference.getIdeaInfos(4321)
+        val ideaInfos1 = fakeFirebaseReference.getIdeaInfos(mUserId,1234)
+        val ideaInfos2 = fakeFirebaseReference.getIdeaInfos(mUserId,4321)
 
         //then
         assertEquals(ideaInfos1?.ideaList?.get(0)?.comment, "이건 dp로 풀어야해")
@@ -83,11 +85,11 @@ class FakeFirebaseIdeaInfo {
     @Test
     fun getIdeaInfos_dontExist_returnNull() {
         //given
-        fakeFirebaseReference.setIdeaInfo(null, "이건 dp로 풀어야해", 1234)
-        fakeFirebaseReference.setIdeaInfo(null, "이건 완탐으로 풀어야해", 4321)
+        fakeFirebaseReference.setIdeaInfo(mUserId,null, "이건 dp로 풀어야해", 1234)
+        fakeFirebaseReference.setIdeaInfo(mUserId,null, "이건 완탐으로 풀어야해", 4321)
 
         //when
-        val ideaInfos = fakeFirebaseReference.getIdeaInfos(12312312)
+        val ideaInfos = fakeFirebaseReference.getIdeaInfos(mUserId,12312312)
 
         //then
         assertNull(ideaInfos)

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseReferenceTest.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseReferenceTest.kt
@@ -1,6 +1,5 @@
 package com.ama.algorithmmanagement.fake
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.Model.DisplayName
 import com.ama.algorithmmanagement.Model.Tag

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseReferenceTest.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseReferenceTest.kt
@@ -6,9 +6,9 @@ import com.ama.algorithmmanagement.Model.DisplayName
 import com.ama.algorithmmanagement.Model.Tag
 import com.ama.algorithmmanagement.Model.TaggedProblem
 import com.ama.algorithmmanagement.utils.DateUtils
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
-
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -16,19 +16,23 @@ import org.junit.runner.RunWith
 class FakeFirebaseReferenceTest {
     lateinit var fakeFirebaseReference: FakeFirebaseReference
     lateinit var fakeSharedPreference: FakeSharedPreference
-
+    lateinit var mUserId: String
+    var mTierType: Int =0
 
     @Before
     fun init() {
-        fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference = FakeSharedPreference()
+        fakeSharedPreference.setUserId("skjh0818")
         fakeSharedPreference.setTierType(1)
+
+        mUserId = fakeSharedPreference.getUserId()!!
+        mTierType = fakeSharedPreference.getTierType()!!
+
 
         fakeFirebaseReference =
             FakeFirebaseReference(
-                ApplicationProvider.getApplicationContext(),
                 FakeFirebaseDataProvider(),
-                fakeSharedPreference
+                DateUtils.createDate()
             )
     }
 
@@ -50,9 +54,9 @@ class FakeFirebaseReferenceTest {
             )
 
         //when
-        fakeFirebaseReference.setTippingProblem(taggedProblem, true, "dp를 사용하면 좋다")
+        fakeFirebaseReference.setTippingProblem(mUserId,taggedProblem, true, "dp를 사용하면 좋다")
 
-        val tippingProblemObject = fakeFirebaseReference.getTippingProblemObject()
+        val tippingProblemObject = fakeFirebaseReference.getTippingProblemObject(mUserId)
 
         //then
         assertEquals(tippingProblemObject?.userId, "skjh0818")
@@ -60,15 +64,15 @@ class FakeFirebaseReferenceTest {
         assertEquals(tippingProblemObject?.problemList?.get(0)?.isShow, true)
         assertEquals(tippingProblemObject?.problemList?.get(0)?.date, DateUtils.createDate())
 
-        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.problemId, 1111)
-        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.acceptedUserCount, 1)
-        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.averageTries, 1.1)
-        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.isLevelLocked, false)
+        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.problemId, 1000)
+        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.acceptedUserCount, 151801)
+        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.averageTries, 2.333)
+        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.isLevelLocked, true)
         assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.isPartial, false)
         assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.isSolvable, true)
-        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.level, 3)
-        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.tags?.size, 0)
-        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.votedUserCount, 1000)
+        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.level, 1)
+        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.tags?.size, 1)
+        assertEquals(tippingProblemObject?.problemList?.get(0)?.problem?.votedUserCount, 17)
 
     }
 
@@ -103,10 +107,10 @@ class FakeFirebaseReferenceTest {
             )
 
         //when
-        fakeFirebaseReference.setTippingProblem(taggedProblem1, true, "dp를 사용하면 좋다")
-        fakeFirebaseReference.setTippingProblem(taggedProblem2, true, "binarySearch를 이욯하면 되겠다")
+        fakeFirebaseReference.setTippingProblem(mUserId,taggedProblem1, true, "dp를 사용하면 좋다")
+        fakeFirebaseReference.setTippingProblem(mUserId,taggedProblem2, true, "binarySearch를 이욯하면 되겠다")
 
-        val tippingProblemObject = fakeFirebaseReference.getTippingProblemObject()
+        val tippingProblemObject = fakeFirebaseReference.getTippingProblemObject(mUserId)
 
         //then
         assertEquals(tippingProblemObject?.userId, "skjh0818")
@@ -125,7 +129,7 @@ class FakeFirebaseReferenceTest {
     @Test
     fun getTippingProblem_dontExist_returnNull() {
         //when
-        val tippingProblemObject = fakeFirebaseReference.getTippingProblemObject()
+        val tippingProblemObject = fakeFirebaseReference.getTippingProblemObject(mUserId)
 
         //then
         assertNull(tippingProblemObject)

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseUserInfo.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseUserInfo.kt
@@ -1,6 +1,5 @@
 package com.ama.algorithmmanagement.fake
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ama.algorithmmanagement.utils.DateUtils
 import org.junit.Assert.*

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseUserInfo.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeFirebaseUserInfo.kt
@@ -2,6 +2,7 @@ package com.ama.algorithmmanagement.fake
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ama.algorithmmanagement.utils.DateUtils
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -11,17 +12,22 @@ import org.junit.runner.RunWith
 class FakeFirebaseUserInfo {
     lateinit var fakeFirebaseReference: FakeFirebaseReference
     lateinit var fakeSharedPreference: FakeSharedPreference
+    lateinit var mUserId: String
+    var mTierType: Int =0
 
     @Before
     fun init() {
-        fakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
-        fakeSharedPreference.setUserIdToLocal("skjh0818")
+        fakeSharedPreference = FakeSharedPreference()
+        fakeSharedPreference.setUserId("skjh0818")
+        fakeSharedPreference.setTierType(1)
+
+        mUserId = fakeSharedPreference.getUserId()!!
+        mTierType = fakeSharedPreference.getTierType()!!
 
         fakeFirebaseReference =
             FakeFirebaseReference(
-                ApplicationProvider.getApplicationContext(),
                 FakeFirebaseDataProvider(),
-                fakeSharedPreference
+                DateUtils.createDate()
             )
     }
 
@@ -32,7 +38,7 @@ class FakeFirebaseUserInfo {
 
 
         //when
-        val userInfo = fakeFirebaseReference.getUserInfo()
+        val userInfo = fakeFirebaseReference.getUserInfo(mUserId)
 
         //then
         assertEquals(userInfo?.userId, "skjh0818")
@@ -43,7 +49,7 @@ class FakeFirebaseUserInfo {
     @Test
     fun getUserInfo_empty_returnNull() {
         //when
-        val userInfo = fakeFirebaseReference.getUserInfo()
+        val userInfo = fakeFirebaseReference.getUserInfo(mUserId)
 
         //then
         assertNull(userInfo)

--- a/app/src/test/java/com/ama/algorithmmanagement/fake/FakeNetworkServiceTest.kt
+++ b/app/src/test/java/com/ama/algorithmmanagement/fake/FakeNetworkServiceTest.kt
@@ -1,11 +1,10 @@
 package com.ama.algorithmmanagement.fake
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -20,10 +19,10 @@ class FakeNetworkServiceTest {
 
     @Before
     fun init() {
-        mFakeSharedPreference = FakeSharedPreference(ApplicationProvider.getApplicationContext())
-        mFakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider(mFakeSharedPreference))
+        mFakeSharedPreference = FakeSharedPreference()
+        mFakeNetworkService = FakeNetworkService(FakeNetWorkDataProvider())
 
-        mFakeSharedPreference.setUserIdToLocal("skjh0818")
+        mFakeSharedPreference.setUserId("skjh0818")
 
     }
 
@@ -31,7 +30,7 @@ class FakeNetworkServiceTest {
     @Test
     fun getSolvedProblems() = runBlockingTest {
         //when
-        val userId = mFakeSharedPreference.getUserIdFromLocal()
+        val userId = mFakeSharedPreference.getUserId()
         val solvedProblems = mFakeNetworkService.getSolvedProblems(userId!!)
 
         //then
@@ -61,7 +60,7 @@ class FakeNetworkServiceTest {
     @Test
     fun getUserStats() = runBlockingTest {
         //when
-        val userid = mFakeSharedPreference.getUserIdFromLocal()
+        val userid = mFakeSharedPreference.getUserId()
         val userStats = mFakeNetworkService.getUserStats(userid!!)
 
         //then


### PR DESCRIPTION
- Result class 삭제
- FakeSharedPref class FakeRepo에서 의존성 주입하는 방식으로 통일
- userId,tierType 데이터 FakeRepo에서 주입하는 방식으로 변경
- FakeNetworkDataProvider의 App 의존성 주입 삭제
- FakeSharedPref의 App의존성 주입 삭제
- FakeRepo에서 일부(stats,BOJUser,searchProblem) 미구현 된 NetworkService 구현 완료
- BaseSharedPref 에 auto login 여부 메서드 추가  
- FakeFirebaseRef에 App 의존성 주입 삭제
- Result 모나드 전부 삭제 후 , throw로 에러 전달
- FakeShared Gson 확인하기
- Locator class 싱글톤 확인
- Repository 의존성 및 메서드 수정