### PR TITLE
Seungho/main screen

### DIFF
--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/main/KMainActivity.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/main/KMainActivity.kt
@@ -20,6 +20,7 @@ import com.ama.algorithmmanagement.domain.entity.TipProblemInfo
 import com.ama.algorithmmanagement.presentation.login.activity.KRLoginActivity
 import com.ama.algorithmmanagement.presentation.main.adapter.KRetryProblemsAdapter
 import com.ama.algorithmmanagement.presentation.main.adapter.KUserDateInfoAdapter
+import com.ama.algorithmmanagement.presentation.main.adapter.SolvedProblemStatsAdapter
 import com.ama.algorithmmanagement.presentation.notip.NoTipActivity
 import com.ama.algorithmmanagement.presentation.retryProblems.RetryProblemsInfoActivity
 import com.ama.algorithmmanagement.presentation.retryProblems.adapter.RetryProblemsInfoAdapter
@@ -73,10 +74,13 @@ class KMainActivity : KBaseActivity<ActivityMainBinding>(R.layout.activity_main)
 
         binding.appBarMain.contentMain.apply {
             viewmodel = mainViewModel
+            // 유형별 통계 프로그래스바 그래프 세팅
+            val statsProblemAdapter = SolvedProblemStatsAdapter()
+            rvTypeStatics.adapter = statsProblemAdapter
             // 다시풀어볼 문제 어댑터 세팅
-            val adapter = RetryProblemsInfoAdapter()
-            rvRetryProblem.adapter = adapter
-            adapter.setOnItemClickListener(object :RetryProblemsInfoAdapter.OnRetryProblemClickListener{
+            val retryProblemAdapter = RetryProblemsInfoAdapter()
+            rvRetryProblem.adapter = retryProblemAdapter
+            retryProblemAdapter.setOnItemClickListener(object :RetryProblemsInfoAdapter.OnRetryProblemClickListener{
                 override fun onClick(v: View, data: TipProblemInfo) {
                     val builder = AlertDialog.Builder(this@KMainActivity)
                     builder.setItems(arrayOf("문제보기 (코멘트 작성화면)","문제풀이 히스토리")
@@ -159,7 +163,6 @@ class KMainActivity : KBaseActivity<ActivityMainBinding>(R.layout.activity_main)
         // 검색화면 누를시
         mainViewModel.isClickSearchInput.observe(this) { isShow ->
             if (isShow) {
-                Toast.makeText(this, "검색화면으로 전환", Toast.LENGTH_SHORT).show()
                 val intent = Intent(this, SearchActivity::class.java)
                 mainViewModel.initIsClickSearchInput() // 화면 전환후 isClickSearchInput 에대한 값은 초기화
                 startActivity(intent)

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/main/KMainViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/main/KMainViewModel.kt
@@ -81,9 +81,9 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
         get() = _isRetryProblemsInfo
 
     // 다시풀어볼 문제 프로그래스바 보여줄지 여부
-    private val _isShowRetryProblemProgressBar = MutableLiveData<Boolean>(false)
-    val isShowRetryProblemProgressBar: LiveData<Boolean>
-        get() = _isShowRetryProblemProgressBar
+    private val _isLoadingProgress = MutableLiveData<Boolean>(true)
+    val isLoadingProgress: LiveData<Boolean>
+        get() = _isLoadingProgress
 
 
     // 월별 통계데이터 불러오기
@@ -214,7 +214,7 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
     private fun loadRetryProblems() {
         viewModelScope.launch {
             try {
-                _isShowRetryProblemProgressBar.value = false
+                _isLoadingProgress.value = true
                 _retryProblems.value = mutableListOf()
                 val tipProblems = mutableListOf<TipProblemInfo>()
                 mRepository.getAllTipProblems()?.let {
@@ -232,7 +232,7 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
                     tipProblems[rangeList[2]],
                     tipProblems[rangeList[3]],
                 )
-                _isShowRetryProblemProgressBar.value = true
+                _isLoadingProgress.value = false
             } catch (e: Exception) {
                 Timber.e(e.message.toString())
             }

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/main/KMainViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/main/KMainViewModel.kt
@@ -77,8 +77,13 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
 
     // 다시풀어볼 문제 자세히 보기 눌렀는지 여부
     private val _isRetryProblemsInfo = MutableLiveData<Boolean>(false)
-    val isRetryProblemsInfo:LiveData<Boolean>
-        get() =_isRetryProblemsInfo
+    val isRetryProblemsInfo: LiveData<Boolean>
+        get() = _isRetryProblemsInfo
+
+    // 다시풀어볼 문제 프로그래스바 보여줄지 여부
+    private val _isShowRetryProblemProgressBar = MutableLiveData<Boolean>(false)
+    val isShowRetryProblemProgressBar: LiveData<Boolean>
+        get() = _isShowRetryProblemProgressBar
 
 
     // 월별 통계데이터 불러오기
@@ -109,10 +114,11 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
         _isOpenDrawer.value = false
     }
 
-    fun openRetryProblemsInfo(){
+    fun openRetryProblemsInfo() {
         _isRetryProblemsInfo.value = true
     }
-    fun initRetryProblemsInfo(){
+
+    fun initRetryProblemsInfo() {
         _isRetryProblemsInfo.value = false
     }
 
@@ -124,7 +130,7 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
                 // 파이어베이스 문제 세팅
                 val firebaseProblems = mutableListOf<TipProblemInfo>()
                 // 팁작성문제,팁을 작성하지 않은문제 두개를 합쳐서 파베에 저장된 문제 저장
-                mRepository.getAllTipProblems()?.problemInfoList?.let{
+                mRepository.getAllTipProblems()?.problemInfoList?.let {
                     firebaseProblems.addAll(it)
                 }
                 val baekjoonSolvedProblems = mRepository.getSolvedProblems().problemList!!
@@ -146,7 +152,7 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
                             }
                         }
                         // 푼문제가 아닐경우 리스트에 추가
-                        mRepository.setTippingProblem(baekjoonProblem,false,null)
+                        mRepository.setTippingProblem(baekjoonProblem, false, null)
                     }
                 }
             } catch (e: Exception) {
@@ -164,7 +170,7 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
                 noTipProblems?.problemInfoList?.map { noTip ->
                     if (noTip.date == DateUtils.getDate()) {
                         Timber.e("today add")
-                        noTip.problem?.let{
+                        noTip.problem?.let {
                             saveProblems.add(it)
                         }
                         Timber.e("${todaySolvedProblem.value}")
@@ -208,8 +214,10 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
     private fun loadRetryProblems() {
         viewModelScope.launch {
             try {
+                _isShowRetryProblemProgressBar.value = false
+                _retryProblems.value = mutableListOf()
                 val tipProblems = mutableListOf<TipProblemInfo>()
-                mRepository.getAllTipProblems()?.let{
+                mRepository.getAllTipProblems()?.let {
                     tipProblems.addAll(it.problemInfoList)
                 }
                 // 0 부터 tipProblem 의 사이즈만큼 rangeList 만든후 shuffle  ex) [0,1,2,3,4,5,6,7] => [5,1,2,0,6,7,3,4] 셔플후
@@ -224,6 +232,7 @@ class KMainViewModel(private val mRepository: BaseRepository) : ViewModel() {
                     tipProblems[rangeList[2]],
                     tipProblems[rangeList[3]],
                 )
+                _isShowRetryProblemProgressBar.value = true
             } catch (e: Exception) {
                 Timber.e(e.message.toString())
             }

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/main/adapter/SolvedProblemStatsAdapter.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/main/adapter/SolvedProblemStatsAdapter.kt
@@ -1,0 +1,30 @@
+package com.ama.algorithmmanagement.presentation.main.adapter;
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.ama.algorithmmanagement.presentation.main.view_holder.SolvedProblemStatsViewHolder
+
+/**
+ * @author SeungHo Lee
+ * summary :
+ */
+class SolvedProblemStatsAdapter :RecyclerView.Adapter<SolvedProblemStatsViewHolder>(){
+    private val mList= mutableListOf<Pair<String,Int>>()
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): SolvedProblemStatsViewHolder {
+        return SolvedProblemStatsViewHolder(parent)
+    }
+
+    override fun onBindViewHolder(holder: SolvedProblemStatsViewHolder, position: Int) {
+        holder.setData(mList[position].second,mList[position].first)
+    }
+
+    override fun getItemCount(): Int= mList.size
+
+    fun addItem(data:Pair<String,Int>){
+        mList.add(data)
+        notifyItemInserted(mList.size-1)
+    }
+}

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/main/view_holder/SolvedProblemStatsViewHolder.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/main/view_holder/SolvedProblemStatsViewHolder.kt
@@ -1,0 +1,22 @@
+package com.ama.algorithmmanagement.presentation.main.view_holder;
+
+import android.view.ViewGroup
+import com.ama.algorithmmanagement.R
+import com.ama.algorithmmanagement.databinding.ItemProblemStatsProgressBarBinding
+import com.ama.algorithmmanagement.domain.base.KBaseViewHolder
+
+/**
+ * @author SeungHo Lee
+ * summary :
+ */
+class SolvedProblemStatsViewHolder(parent: ViewGroup) :
+    KBaseViewHolder<ItemProblemStatsProgressBarBinding>(
+        parent,
+        R.layout.item_problem_stats_progress_bar
+    ) {
+        fun setData(progress:Int,title:String){
+            binding.pgItemProgressProblem.progress = progress
+            binding.tvProgressTitle.text = title
+            binding.tvSolvedCount.text = "$progress 개 해결"
+        }
+}

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/retryProblems/adapter/RetryProblemsInfoAdapter.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/retryProblems/adapter/RetryProblemsInfoAdapter.kt
@@ -42,6 +42,5 @@ class RetryProblemsInfoAdapter: RecyclerView.Adapter<RetryProblemInfoViewHolder>
     }
     fun clearData(){
         mList.clear()
-        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/retryProblems/adapter/RetryProblemsInfoAdapter.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/retryProblems/adapter/RetryProblemsInfoAdapter.kt
@@ -36,10 +36,12 @@ class RetryProblemsInfoAdapter: RecyclerView.Adapter<RetryProblemInfoViewHolder>
     }
 
     fun setData(data:MutableList<TipProblemInfo>){
+        clearData()
         mList.addAll(data)
         notifyDataSetChanged()
     }
     fun clearData(){
         mList.clear()
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/search/SearchActivity.kt
@@ -53,7 +53,7 @@ class SearchActivity : KBaseActivity<ActivitySearchBinding>(R.layout.activity_se
                 if (p0.toString() == "") {
                     viewModel.clearSearchProblems()
                 }
-                if (p0.toString().isNotEmpty() && p0.toString().isNotBlank()) {
+                else if (p0.toString().isNotEmpty() && p0.toString().isNotBlank()) {
                     viewModel.callSearchQueryProblem(p0.toString())
                 }
             }

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/search/SearchViewModel.kt
@@ -48,6 +48,8 @@ class SearchViewModel(private val mRepository: BaseRepository) : ViewModel() {
     }
 
     fun clearSearchProblems() {
+        // 검색결과가 0.6 초 뒤에 호출되기떄문에 입력창을 0.6 초 이내에 지울경우 코루틴 스코프가 실행되어 검색결과가 나옴
+        debounceJob?.cancel()
         _searchProblems.value = AutoKeywordObject(
             keywords = listOf(),
             autocomplete = listOf(),

--- a/app/src/main/java/com/ama/algorithmmanagement/presentation/status/CategoryStatusActivity.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/presentation/status/CategoryStatusActivity.kt
@@ -8,6 +8,7 @@ import com.ama.algorithmmanagement.data.repositories.RepositoryLocator
 import com.ama.algorithmmanagement.databinding.ActivityCategorySolvedProblemBinding
 import com.ama.algorithmmanagement.domain.base.BaseViewModelFactory
 import com.ama.algorithmmanagement.domain.base.KBaseActivity
+import com.ama.algorithmmanagement.presentation.main.adapter.SolvedProblemStatsAdapter
 
 /**
  * @author SeungHo Lee
@@ -23,6 +24,7 @@ class CategoryStatusActivity :
             BaseViewModelFactory(RepositoryLocator().getRepository(AMAApplication.INSTANCE))
         )[CategoryStatusViewModel::class.java]
         binding.viewmodel = viewModel
+        binding.rvSolvedProblemType.adapter = SolvedProblemStatsAdapter()
     }
 
 }

--- a/app/src/main/java/com/ama/algorithmmanagement/utils/BindingAdapterUtils.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/utils/BindingAdapterUtils.kt
@@ -1,6 +1,8 @@
 package com.ama.algorithmmanagement.utils
 
 import android.graphics.Color
+import android.view.View
+import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
@@ -9,6 +11,7 @@ import com.ama.algorithmmanagement.presentation.search.adapter.SearchProblemAdap
 import com.ama.algorithmmanagement.domain.entity.*
 import com.ama.algorithmmanagement.presentation.main.adapter.KRetryProblemsAdapter
 import com.ama.algorithmmanagement.presentation.main.adapter.KUserDateInfoAdapter
+import com.ama.algorithmmanagement.presentation.main.adapter.SolvedProblemStatsAdapter
 import com.ama.algorithmmanagement.presentation.mytip.adapter.MyTipProblemsAdapter
 import com.ama.algorithmmanagement.presentation.newSolvedProblem.SolvedProblemViewPagerFragment
 import com.ama.algorithmmanagement.presentation.newSolvedProblem.adapter.TipProblemViewPagerFragmentAdapter
@@ -124,8 +127,8 @@ object BindingAdapterUtils {
     ) {
         val adapter = recyclerView.adapter as? RetryProblemsInfoAdapter
         Timber.e("solved $retryProblem")
-        retryProblem?.slice(IntRange(0, 3))?.let {
-            adapter?.setData(it.toMutableList())
+        retryProblem?.let { list ->
+            adapter?.setData(list.toMutableList())
         }
 
     }
@@ -145,11 +148,13 @@ object BindingAdapterUtils {
         position: Int?
     ) {
         val entries = mutableListOf<PieEntry>()
+        pieChart.visibility = View.VISIBLE
         position?.let { pos ->
             // 티어가 0~31 까지 있고 5단위로 티어가 바뀌기떄문에 start 와 end 값 세팅
             // 0 은 언랭 티어기떄문에 브론즈 티어는 1부터 시작
             val start = (0 + pos) * 5 + 1
             val end = start + 5 - 1
+            var solvedCount = 0
             setSolvedProblemTierPieChart?.let {
                 for (i in start..end) {
                     // 해당 티어에 해결한 문제가 있을때만 그림
@@ -160,7 +165,11 @@ object BindingAdapterUtils {
                                 ColorUtils.intConvertToTier(i)
                             )
                         )
+                        solvedCount++
                     }
+                }
+                if (solvedCount == 0) {
+                    pieChart.visibility = View.GONE
                 }
             }
             // 티어에 맞는 색상 지정
@@ -189,6 +198,34 @@ object BindingAdapterUtils {
         pieChart.invalidate()
     }
 
+    @JvmStatic
+    @BindingAdapter("handleNotSolvedProblem", "tierPosition")
+    fun handleNotSolvedProblem(
+        view: TextView,
+        handleNotSolvedProblem: MutableList<Stats>?,
+        position: Int?
+    ) {
+        view.visibility = View.GONE
+        position?.let { pos ->
+            // 티어가 0~31 까지 있고 5단위로 티어가 바뀌기떄문에 start 와 end 값 세팅
+            // 0 은 언랭 티어기떄문에 브론즈 티어는 1부터 시작
+            val start = (0 + pos) * 5 + 1
+            val end = start + 5 - 1
+            var solvedCount = 0
+            handleNotSolvedProblem?.let {
+                for (i in start..end) {
+                    // 해당 티어에 해결한 문제가 있을때만 그림
+                    if (it[i].solved != 0) {
+                        solvedCount++
+                    }
+                }
+                if (solvedCount == 0) {
+                    view.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+
     /**
      * @param barChart horizontalBarChart 수직 막대그래프
      * @param problems 유저가 해결한 문제에대한 정보가 담긴 객체
@@ -196,88 +233,16 @@ object BindingAdapterUtils {
      */
     @JvmStatic
     @BindingAdapter("setSolvedProblemTypeBarChart")
-    fun setSolvedProblemTypeBarChart(barChart: HorizontalBarChart, problems: Problems?) {
+    fun setSolvedProblemTypeBarChart(recyclerView: RecyclerView, problems: Problems?) {
         problems?.problemList?.let {
             // 메인화면에 보여줄 그래프는 10개로 세팅
-            val solvedType = MpChartUtils.getTypeStatsSize(it, 10, false)
-            val values = mutableListOf<BarEntry>()
-
-            solvedType.onEachIndexed { index, it ->
-                values.add(BarEntry(index.toFloat(), it.value.toFloat()))
+            val adapter = recyclerView.adapter as? SolvedProblemStatsAdapter
+            val problemHashMap = MpChartUtils.getTypeStatsSize(it,10,false)
+            Timber.e("hashmap $problemHashMap")
+            problemHashMap.toList().map { item->
+                adapter?.addItem(item)
             }
 
-            val set = BarDataSet(values, "유형별 통계")
-                .apply {
-                    setDrawIcons(false)
-                    setDrawValues(true)
-                    valueFormatter = MpChartUtils.ScoreCustomFormatter()
-                    valueTextColor = Color.RED
-                    colors = mutableListOf(
-                        barChart.context.resources.getColor(
-                            R.color.barchart_color
-                        )
-                    )
-                }
-
-
-            val dataSets = mutableListOf<IBarDataSet>()
-            dataSets.add(set)
-
-            val datas = BarData(dataSets)
-                .apply {
-                    setValueTextSize(10f)
-
-                    barWidth = 0.5f
-                }
-            Timber.e("solved Type :$solvedType")
-            barChart.run {
-                setDrawBarShadow(true) // 그래프 그림자
-                setTouchEnabled(false) // 차트 터치 막기
-                setDrawValueAboveBar(true) // 입력?값이 차트 위or아래에 그려질 건지 (true=위, false=아래)
-                setPinchZoom(false) // 두손가락으로 줌 설정
-                setDrawGridBackground(false) // 격자구조
-                description.isEnabled = false // 그래프 오른쪽 하단에 라벨 표시
-                legend.isEnabled = false // 차트 범례 설정(legend object chart)
-
-                // horizontal chart bar  이기때문에 x 축과 y축이 반대임
-                xAxis.run { // 아래 라벨 x축
-                    isEnabled = true // 라벨 표시 설정 이속성은 valueFormatter 와 연관있는듯
-                    valueFormatter =
-                        MpChartUtils.LabelCustomFormatter(solvedType.keys.toList()) // 라벨 값 포멧 설정
-                    position = XAxis.XAxisPosition.BOTTOM // 라벨 위치 설정
-                    setDrawGridLines(false) // 격자구조
-                    setDrawLimitLinesBehindData(true)
-                    setDrawAxisLine(false)
-                    setLabelCount(
-                        solvedType.toList().size,
-                        false
-                    ) // mpchart 는 그리려는 그래프(Bar) 가 많아지면 특정 구간마다 레이블이 작성되는데 이속성을 통해 모든 그래프마다 레이블 보여주게 함
-                    textSize = 12f // 라벨 크기
-                    textColor = Color.BLACK
-                }
-
-                axisLeft.run { // 왼쪽 y축
-                    isEnabled = false
-                    axisMinimum = 0f // 최소값
-                    axisMaximum = 100f // 최대값
-                    granularity = 10f // 값 만큼 라인선 설정
-                    setDrawLabels(false) // 값 셋팅 설정
-                    textColor = Color.RED // 색상 설정
-                    axisLineColor = Color.BLACK // 축 색상 설정
-                    gridColor = Color.BLUE // 격자 색상 설정
-                }
-                axisRight.run { // 오른쪽 y축(왼쪽과동일)
-                    isEnabled = false
-                    textSize = 15f
-                }
-
-                animateY(1500) // y축 애니메이션
-                animateX(1000) // x축 애니메이션
-            }
-
-            barChart.moveViewToX(0f)
-            barChart.invalidate()
-            barChart.data = datas
         }
     }
 
@@ -361,93 +326,16 @@ object BindingAdapterUtils {
 
     @JvmStatic
     @BindingAdapter("bind_loadCategoryStatus")
-    fun loadCategoryStatus(barChart: HorizontalBarChart, problems: Problems?) {
+    fun loadCategoryStatus(recyclerView: RecyclerView, problems: Problems?) {
         problems?.problemList?.let {
             // 메인화면에 보여줄 그래프는 10개로 세팅
-            val solvedType = MpChartUtils.getTypeStatsSize(it, isAll = true)
-            Timber.e("solved Type :$solvedType")
-            val values = mutableListOf<BarEntry>()
-//            val colorList = ColorTemplate.VORDIPLOM_COLORS
-
-            solvedType.onEachIndexed { index, it ->
-                values.add(BarEntry(index.toFloat(), it.value.toFloat()))
+            val adapter = recyclerView.adapter as? SolvedProblemStatsAdapter
+            val problemHashMap = MpChartUtils.getTypeStatsSize(it, isAll = true)
+            Timber.e("hashmap $problemHashMap")
+            problemHashMap.toList().map { item->
+                adapter?.addItem(item)
             }
 
-            val set = BarDataSet(values, "유형별 통계")
-                .apply {
-                    setDrawIcons(false)
-                    setDrawValues(true)
-                    valueTextSize = 9f
-                    valueFormatter = MpChartUtils.ScoreCustomFormatter()
-                    valueTextColor = Color.RED
-
-                    colors = mutableListOf(
-                        barChart.context.resources.getColor(
-                            R.color.barchart_color
-                        )
-                    )
-                }
-
-
-            val dataSets = mutableListOf<IBarDataSet>()
-            dataSets.add(set)
-
-            val datas = BarData(dataSets)
-                .apply {
-                    setValueTextSize(10f)
-                    barWidth = 0.5f
-                }
-
-            barChart.run {
-                invalidate()
-                data = datas
-                enableScroll()
-
-                setVisibleXRangeMaximum(10f) // 한페이지에 10개만 보이게하기
-                setDrawBarShadow(true) // 그래프 그림자
-                setDrawValueAboveBar(true) // 입력?값이 차트 위or아래에 그려질 건지 (true=위, false=아래)
-                setPinchZoom(false) // 두손가락으로 줌 설정
-                setDrawGridBackground(false) // 격자구조
-                description.isEnabled = false // 그래프 오른쪽 하단에 라벨 표시
-                legend.isEnabled = false // 차트 범례 설정(legend object chart)
-
-                // horizontal chart bar  이기때문에 x 축과 y축이 반대임
-                xAxis.run { // 아래 라벨 x축
-                    isEnabled = true // 라벨 표시 설정 이속성은 valueFormatter 와 연관있는듯
-                    valueFormatter =
-                        MpChartUtils.LabelCustomFormatter(solvedType.keys.toList()) // 라벨 값 포멧 설정
-                    position = XAxis.XAxisPosition.BOTTOM // 라벨 위치 설정
-                    setDrawGridLines(false) // 격자구조
-                    setDrawLimitLinesBehindData(false)
-                    setDrawAxisLine(false)
-                    setLabelCount(
-                        10,
-                        false
-                    ) // mpchart 는 그리려는 그래프(Bar) 가 많아지면 특정 구간마다 레이블이 작성되는데 이속성을 통해 모든 그래프마다 레이블 보여주게 함
-                    textSize = 12f // 라벨 크기
-                    textColor = Color.BLACK
-                }
-
-                axisLeft.run { // 왼쪽 y축
-                    isEnabled = false
-                    axisMinimum = 0f // 최소값
-                    axisMaximum = 1000f // 최대값
-                    granularity = 100f // 값 만큼 라인선 설정
-
-
-                    setDrawLabels(true) // 값 셋팅 설정
-                    textColor = Color.RED // 색상 설정
-                    axisLineColor = Color.BLACK // 축 색상 설정
-                    gridColor = Color.BLUE // 격자 색상 설정
-                }
-                axisRight.run { // 오른쪽 y축(왼쪽과동일)
-                    isEnabled = false
-                    textSize = 15f
-                }
-
-                animateY(1500) // y축 애니메이션
-                animateX(1000) // x축 애니메이션
-            }
         }
 
 

--- a/app/src/main/java/com/ama/algorithmmanagement/utils/BindingAdapterUtils.kt
+++ b/app/src/main/java/com/ama/algorithmmanagement/utils/BindingAdapterUtils.kt
@@ -153,7 +153,7 @@ object BindingAdapterUtils {
             // 티어가 0~31 까지 있고 5단위로 티어가 바뀌기떄문에 start 와 end 값 세팅
             // 0 은 언랭 티어기떄문에 브론즈 티어는 1부터 시작
             val start = (0 + pos) * 5 + 1
-            val end = start + 5 - 1
+            val end = start + 4
             var solvedCount = 0
             setSolvedProblemTierPieChart?.let {
                 for (i in start..end) {
@@ -210,7 +210,7 @@ object BindingAdapterUtils {
             // 티어가 0~31 까지 있고 5단위로 티어가 바뀌기떄문에 start 와 end 값 세팅
             // 0 은 언랭 티어기떄문에 브론즈 티어는 1부터 시작
             val start = (0 + pos) * 5 + 1
-            val end = start + 5 - 1
+            val end = start + 4
             var solvedCount = 0
             handleNotSolvedProblem?.let {
                 for (i in start..end) {

--- a/app/src/main/res/layout/activity_category_solved_problem.xml
+++ b/app/src/main/res/layout/activity_category_solved_problem.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable
             name="viewmodel"
@@ -10,8 +11,12 @@
     <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <com.github.mikephil.charting.charts.HorizontalBarChart
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_solved_problem_type"
             android:layout_width="match_parent"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            android:orientation="vertical"
+            tools:listitem="@layout/item_problem_stats_progress_bar"
             bind_loadCategoryStatus="@{viewmodel.userAllStats}"
             android:layout_height="match_parent"/>
 

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -13,6 +13,8 @@
             name="viewmodel"
             type="com.ama.algorithmmanagement.presentation.main.KMainViewModel" />
 
+        <import type="android.view.View"/>
+
     </data>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -99,6 +101,7 @@
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/cl_retry_problem_layout"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="41dp"
@@ -143,6 +146,16 @@
                             app:setRetryProblemList="@{viewmodel.retryProblems}"
                             tools:itemCount="4"
                             tools:listitem="@layout/item_retry_problem" />
+
+                        <ProgressBar
+                            android:id="@+id/pg_retry_problem"
+                            android:visibility="@{viewmodel.isShowRetryProblemProgressBar()?View.GONE:View.VISIBLE}"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintBottom_toBottomOf="@+id/cl_retry_problem_layout"
+                            app:layout_constraintEnd_toEndOf="@+id/rv_retry_problem"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/textView3" />
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
@@ -228,8 +241,18 @@
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/tiers_tab">
-
                         </com.github.mikephil.charting.charts.PieChart>
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="300dp"
+                            android:text="해당 티어에는 해결한 문제가 없습니다."
+                            app:layout_constraintEnd_toEndOf="parent"
+                            android:gravity="center"
+                            handleNotSolvedProblem="@{viewmodel.userStats}"
+                            tierPosition="@{position}"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/tiers_tab" />
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -279,12 +302,17 @@
 
                         </LinearLayout>
 
-                        <com.github.mikephil.charting.charts.HorizontalBarChart
-                            android:id="@+id/mp_lc_type_statics"
-                            setSolvedProblemTypeBarChart="@{viewmodel.userSolvedProblem}"
+
+                        <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/rv_type_statics"
                             android:layout_width="match_parent"
                             android:layout_height="300dp"
                             android:layout_marginTop="12dp"
+                            tools:itemCount="3"
+                            android:orientation="vertical"
+                            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                            setSolvedProblemTypeBarChart="@{viewmodel.userSolvedProblem}"
+                            tools:listitem="@layout/item_problem_stats_progress_bar"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/textView10" />
 
@@ -309,6 +337,16 @@
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
+                        <ImageView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:onClick="@{()->viewmodel.previousMonth()}"
+                            android:background="@drawable/ic_arrow_left"
+                            app:layout_constraintBottom_toBottomOf="@+id/textView6"
+                            app:layout_constraintEnd_toStartOf="@+id/textView6"
+                            app:layout_constraintTop_toTopOf="@+id/textView6" />
+
                         <TextView
                             android:id="@+id/textView6"
                             android:layout_width="wrap_content"
@@ -324,6 +362,16 @@
                             app:layout_constraintEnd_toEndOf="@+id/date_weeekday"
                             app:layout_constraintStart_toStartOf="@+id/date_weeekday"
                             app:layout_constraintTop_toBottomOf="@+id/textView11" />
+
+                        <ImageView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:background="@drawable/ic_arrow_right"
+                            android:onClick="@{()->viewmodel.nextMonth()}"
+                            app:layout_constraintBottom_toBottomOf="@id/textView6"
+                            app:layout_constraintStart_toEndOf="@+id/textView6"
+                            app:layout_constraintTop_toTopOf="@id/textView6" />
 
                         <LinearLayout
                             android:id="@+id/date_weeekday"
@@ -414,25 +462,6 @@
                                 android:textSize="14sp"
                                 android:textStyle="bold" />
                         </LinearLayout>
-
-
-                        <LinearLayout
-                            android:orientation="horizontal"
-                            android:id="@+id/imageView"
-                            android:layout_width="wrap_content"
-                            android:layout_height="0dp"
-                            android:onClick="@{()->viewmodel.previousMonth()}"
-                            app:layout_constraintBottom_toBottomOf="@+id/rv_date_grid"
-                            app:layout_constraintEnd_toStartOf="@+id/rv_date_grid"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="@+id/rv_date_grid" >
-                            <ImageView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center"
-                                android:background="@drawable/ic_arrow_left"/>
-                        </LinearLayout>
-
                         <androidx.recyclerview.widget.RecyclerView
                             android:id="@+id/rv_date_grid"
                             android:layout_width="wrap_content"
@@ -441,37 +470,15 @@
                             app:currentDate="@{viewmodel.dateStatsCurrentDate}"
                             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toStartOf="@+id/imageView3"
-                            app:layout_constraintStart_toEndOf="@+id/imageView"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/date_weeekday"
                             app:setDateInfoGridList="@{viewmodel.userDateInfo}"
                             app:spanCount="7"
                             tools:itemCount="30"
                             tools:listitem="@layout/item_user_date_info" />
-
-                        <LinearLayout
-                            android:id="@+id/imageView3"
-                            android:layout_width="wrap_content"
-                            android:layout_height="0dp"
-                            android:onClick="@{()->viewmodel.nextMonth()}"
-                            android:orientation="horizontal"
-                            app:layout_constraintBottom_toBottomOf="@+id/rv_date_grid"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="@+id/rv_date_grid" >
-                            <ImageView
-                                android:layout_gravity="center"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:background="@drawable/ic_arrow_right"/>
-
-                        </LinearLayout>
-
-
                     </androidx.constraintlayout.widget.ConstraintLayout>
-
                 </LinearLayout>
-
-
             </androidx.core.widget.NestedScrollView>
 
         </LinearLayout>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -149,7 +149,7 @@
 
                         <ProgressBar
                             android:id="@+id/pg_retry_problem"
-                            android:visibility="@{viewmodel.isShowRetryProblemProgressBar()?View.GONE:View.VISIBLE}"
+                            android:visibility="@{viewmodel.isLoadingProgress()?View.VISIBLE:View.GONE}"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             app:layout_constraintBottom_toBottomOf="@+id/cl_retry_problem_layout"

--- a/app/src/main/res/layout/item_problem_stats_progress_bar.xml
+++ b/app/src/main/res/layout/item_problem_stats_progress_bar.xml
@@ -14,7 +14,6 @@
             android:id="@+id/tv_progress_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="유형"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
         <FrameLayout
@@ -27,13 +26,12 @@
                 style="@android:style/Widget.ProgressBar.Horizontal"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:max="100"
-                android:progress="32"/>
+                android:max="100" />
             <TextView
                 android:id="@+id/tv_solved_count"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="fads"/>
+                />
         </FrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_problem_stats_progress_bar.xml
+++ b/app/src/main/res/layout/item_problem_stats_progress_bar.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+    <data>
+
+    </data>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="4dp">
+        <TextView
+            android:id="@+id/tv_progress_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="유형"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="@+id/tv_progress_title"
+            app:layout_constraintTop_toBottomOf="@+id/tv_progress_title" >
+            <ProgressBar
+                android:id="@+id/pg_item_progress_problem"
+                style="@android:style/Widget.ProgressBar.Horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="100"
+                android:progress="32"/>
+            <TextView
+                android:id="@+id/tv_solved_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="fads"/>
+        </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>
+


### PR DESCRIPTION
1. 검색쪽 핸들링 ( 입력창을 지울때 리사이클러뷰 어댑터랑 코루틴 job 도 cancel 해야 깔끔히 처리됨)
2. 날짜별통계 화살표 위치변경
3. 유형별통계 리사이클러뷰랑 프로그래스바로 커스텀
4. 다시풀어볼문제 원형 프로그래스바로 로딩화면 
5. 검색화면 이동시 토스트 삭제
6. swipe refresh 할때마다 다시풀어볼 문제가 계속 추가되는 이슈 서정
7. 티어별 통계에서 해당 티어에 푼 문제가 없을시 텍스트로 사용자에게 알려줌